### PR TITLE
Alternative struct for Groth16 Verification Key

### DIFF
--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
@@ -167,18 +167,21 @@ std::istream& operator>>(std::istream &in, r1cs_gg_ppzksnark_verification_key<pp
 template<typename ppT>
 class r1cs_gg_ppzksnark_verification_key {
 public:
-    libff::GT<ppT> alpha_g1_beta_g2;
+    libff::G1<ppT> alpha_g1;
+    libff::G2<ppT> beta_g2;
     libff::G2<ppT> gamma_g2;
     libff::G2<ppT> delta_g2;
 
     accumulation_vector<libff::G1<ppT> > gamma_ABC_g1;
 
     r1cs_gg_ppzksnark_verification_key() = default;
-    r1cs_gg_ppzksnark_verification_key(const libff::GT<ppT> &alpha_g1_beta_g2,
+    r1cs_gg_ppzksnark_verification_key(const libff::G1<ppT> &alpha_g1,
+                                       const libff::G2<ppT> &beta_g2,
                                        const libff::G2<ppT> &gamma_g2,
                                        const libff::G2<ppT> &delta_g2,
                                        const accumulation_vector<libff::G1<ppT> > &gamma_ABC_g1) :
-        alpha_g1_beta_g2(alpha_g1_beta_g2),
+        alpha_g1(alpha_g1),
+        beta_g2(beta_g2),
         gamma_g2(gamma_g2),
         delta_g2(delta_g2),
         gamma_ABC_g1(gamma_ABC_g1)
@@ -186,30 +189,24 @@ public:
 
     size_t G1_size() const
     {
-        return gamma_ABC_g1.size();
+        return gamma_ABC_g1.size() + 1;
     }
 
     size_t G2_size() const
     {
-        return 2;
-    }
-
-    size_t GT_size() const
-    {
-        return 1;
+        return 3;
     }
 
     size_t size_in_bits() const
     {
-        // TODO: include GT size
-        return (gamma_ABC_g1.size_in_bits() + 2 * libff::G2<ppT>::size_in_bits());
+
+        return (gamma_ABC_g1.size_in_bits() + 3 * libff::G2<ppT>::size_in_bits() + libff::G1<ppT>::size_in_bits());
     }
 
     void print_size() const
     {
         libff::print_indent(); printf("* G1 elements in VK: %zu\n", this->G1_size());
         libff::print_indent(); printf("* G2 elements in VK: %zu\n", this->G2_size());
-        libff::print_indent(); printf("* GT elements in VK: %zu\n", this->GT_size());
         libff::print_indent(); printf("* VK size in bits: %zu\n", this->size_in_bits());
     }
 
@@ -242,7 +239,8 @@ std::istream& operator>>(std::istream &in, r1cs_gg_ppzksnark_processed_verificat
 template<typename ppT>
 class r1cs_gg_ppzksnark_processed_verification_key {
 public:
-    libff::GT<ppT> vk_alpha_g1_beta_g2;
+    libff::G1_precomp<ppT> vk_alpha_g1_precomp;
+    libff::G2_precomp<ppT> vk_beta_g2_precomp; 
     libff::G2_precomp<ppT> vk_gamma_g2_precomp;
     libff::G2_precomp<ppT> vk_delta_g2_precomp;
 

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
@@ -563,7 +563,7 @@ bool r1cs_gg_ppzksnark_online_verifier_weak_IC(const r1cs_gg_ppzksnark_processed
     const libff::G1_precomp<ppT> proof_g_C_precomp = ppT::precompute_G1(proof.g_C);
     const libff::G1_precomp<ppT> acc_precomp = ppT::precompute_G1(acc);
 
-    const libff::GT<ppT> f = ppT::miller_loop(pvk.vk_alpha_g1_precomp,  pvk.vk_beta_g2_precomp);
+    const libff::Fqk<ppT> f = ppT::miller_loop(pvk.vk_alpha_g1_precomp,  pvk.vk_beta_g2_precomp);
     const libff::GT<ppT> vk_alpha_g1_beta_g2 = ppT::final_exponentiation(f);
 
     const libff::Fqk<ppT> QAP1 = ppT::miller_loop(proof_g_A_precomp,  proof_g_B_precomp);

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
@@ -90,7 +90,8 @@ std::istream& operator>>(std::istream &in, r1cs_gg_ppzksnark_proving_key<ppT> &p
 template<typename ppT>
 bool r1cs_gg_ppzksnark_verification_key<ppT>::operator==(const r1cs_gg_ppzksnark_verification_key<ppT> &other) const
 {
-    return (this->alpha_g1_beta_g2 == other.alpha_g1_beta_g2 &&
+    return (this->alpha_g1 == other.alpha_g1 &&
+            this->beta_g2 == other.beta_g2 &&
             this->gamma_g2 == other.gamma_g2 &&
             this->delta_g2 == other.delta_g2 &&
             this->gamma_ABC_g1 == other.gamma_ABC_g1);
@@ -99,7 +100,8 @@ bool r1cs_gg_ppzksnark_verification_key<ppT>::operator==(const r1cs_gg_ppzksnark
 template<typename ppT>
 std::ostream& operator<<(std::ostream &out, const r1cs_gg_ppzksnark_verification_key<ppT> &vk)
 {
-    out << vk.alpha_g1_beta_g2 << OUTPUT_NEWLINE;
+    out << vk.alpha_g1 << OUTPUT_NEWLINE;
+    out << vk.beta_g2 << OUTPUT_NEWLINE;
     out << vk.gamma_g2 << OUTPUT_NEWLINE;
     out << vk.delta_g2 << OUTPUT_NEWLINE;
     out << vk.gamma_ABC_g1 << OUTPUT_NEWLINE;
@@ -110,7 +112,9 @@ std::ostream& operator<<(std::ostream &out, const r1cs_gg_ppzksnark_verification
 template<typename ppT>
 std::istream& operator>>(std::istream &in, r1cs_gg_ppzksnark_verification_key<ppT> &vk)
 {
-    in >> vk.alpha_g1_beta_g2;
+    in >> vk.alpha_g1;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> vk.beta_g2;
     libff::consume_OUTPUT_NEWLINE(in);
     in >> vk.gamma_g2;
     libff::consume_OUTPUT_NEWLINE(in);
@@ -125,7 +129,8 @@ std::istream& operator>>(std::istream &in, r1cs_gg_ppzksnark_verification_key<pp
 template<typename ppT>
 bool r1cs_gg_ppzksnark_processed_verification_key<ppT>::operator==(const r1cs_gg_ppzksnark_processed_verification_key<ppT> &other) const
 {
-    return (this->vk_alpha_g1_beta_g2 == other.vk_alpha_g1_beta_g2 &&
+    return (this->vk_alpha_g1_precomp == other.vk_alpha_g1_precomp &&
+            this->vk_beta_g2_precomp == other.vk_beta_g2_precomp &&
             this->vk_gamma_g2_precomp == other.vk_gamma_g2_precomp &&
             this->vk_delta_g2_precomp == other.vk_delta_g2_precomp &&
             this->gamma_ABC_g1 == other.gamma_ABC_g1);
@@ -134,7 +139,8 @@ bool r1cs_gg_ppzksnark_processed_verification_key<ppT>::operator==(const r1cs_gg
 template<typename ppT>
 std::ostream& operator<<(std::ostream &out, const r1cs_gg_ppzksnark_processed_verification_key<ppT> &pvk)
 {
-    out << pvk.vk_alpha_g1_beta_g2 << OUTPUT_NEWLINE;
+    out << pvk.vk_alpha_g1_precomp << OUTPUT_NEWLINE;
+    out << pvk.vk_beta_g2_precomp << OUTPUT_NEWLINE;
     out << pvk.vk_gamma_g2_precomp << OUTPUT_NEWLINE;
     out << pvk.vk_delta_g2_precomp << OUTPUT_NEWLINE;
     out << pvk.gamma_ABC_g1 << OUTPUT_NEWLINE;
@@ -145,7 +151,9 @@ std::ostream& operator<<(std::ostream &out, const r1cs_gg_ppzksnark_processed_ve
 template<typename ppT>
 std::istream& operator>>(std::istream &in, r1cs_gg_ppzksnark_processed_verification_key<ppT> &pvk)
 {
-    in >> pvk.vk_alpha_g1_beta_g2;
+    in >> pvk.vk_alpha_g1_precomp;
+    libff::consume_OUTPUT_NEWLINE(in);
+    in >> pvk.vk_beta_g2_precomp;
     libff::consume_OUTPUT_NEWLINE(in);
     in >> pvk.vk_gamma_g2_precomp;
     libff::consume_OUTPUT_NEWLINE(in);
@@ -192,7 +200,8 @@ template<typename ppT>
 r1cs_gg_ppzksnark_verification_key<ppT> r1cs_gg_ppzksnark_verification_key<ppT>::dummy_verification_key(const size_t input_size)
 {
     r1cs_gg_ppzksnark_verification_key<ppT> result;
-    result.alpha_g1_beta_g2 = libff::Fr<ppT>::random_element() * libff::GT<ppT>::random_element();
+    result.alpha_g1 = libff::G1<ppT>::random_element();
+    result.beta_g2 = libff::G2<ppT>::random_element();
     result.gamma_g2 = libff::G2<ppT>::random_element();
     result.delta_g2 = libff::G2<ppT>::random_element();
 
@@ -352,7 +361,6 @@ r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksna
     libff::leave_block("Generate R1CS proving key");
 
     libff::enter_block("Generate R1CS verification key");
-    libff::GT<ppT> alpha_g1_beta_g2 = ppT::reduced_pairing(alpha_g1, beta_g2);
     libff::G2<ppT> gamma_g2 = gamma * G2_gen;
 
     libff::enter_block("Encode gamma_ABC for R1CS verification key");
@@ -365,7 +373,8 @@ r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksna
 
     accumulation_vector<libff::G1<ppT> > gamma_ABC_g1(std::move(gamma_ABC_g1_0), std::move(gamma_ABC_g1_values));
 
-    r1cs_gg_ppzksnark_verification_key<ppT> vk = r1cs_gg_ppzksnark_verification_key<ppT>(alpha_g1_beta_g2,
+    r1cs_gg_ppzksnark_verification_key<ppT> vk = r1cs_gg_ppzksnark_verification_key<ppT>(alpha_g1,
+                                                                                         beta_g2,
                                                                                          gamma_g2,
                                                                                          delta_g2,
                                                                                          gamma_ABC_g1);
@@ -510,7 +519,8 @@ r1cs_gg_ppzksnark_processed_verification_key<ppT> r1cs_gg_ppzksnark_verifier_pro
     libff::enter_block("Call to r1cs_gg_ppzksnark_verifier_process_vk");
 
     r1cs_gg_ppzksnark_processed_verification_key<ppT> pvk;
-    pvk.vk_alpha_g1_beta_g2 = vk.alpha_g1_beta_g2;
+    pvk.vk_alpha_g1_precomp = ppT::precompute_G1(vk.alpha_g1);
+    pvk.vk_beta_g2_precomp = ppT::precompute_G2(vk.beta_g2);
     pvk.vk_gamma_g2_precomp = ppT::precompute_G2(vk.gamma_g2);
     pvk.vk_delta_g2_precomp = ppT::precompute_G2(vk.delta_g2);
     pvk.gamma_ABC_g1 = vk.gamma_ABC_g1;
@@ -553,13 +563,16 @@ bool r1cs_gg_ppzksnark_online_verifier_weak_IC(const r1cs_gg_ppzksnark_processed
     const libff::G1_precomp<ppT> proof_g_C_precomp = ppT::precompute_G1(proof.g_C);
     const libff::G1_precomp<ppT> acc_precomp = ppT::precompute_G1(acc);
 
+    const libff::GT<ppT> f = ppT::miller_loop(pvk.vk_alpha_g1_precomp,  pvk.vk_beta_g2_precomp);
+    const libff::GT<ppT> vk_alpha_g1_beta_g2 = ppT::final_exponentiation(f);
+
     const libff::Fqk<ppT> QAP1 = ppT::miller_loop(proof_g_A_precomp,  proof_g_B_precomp);
     const libff::Fqk<ppT> QAP2 = ppT::double_miller_loop(
         acc_precomp, pvk.vk_gamma_g2_precomp,
         proof_g_C_precomp, pvk.vk_delta_g2_precomp);
     const libff::GT<ppT> QAP = ppT::final_exponentiation(QAP1 * QAP2.unitary_inverse());
 
-    if (QAP != pvk.vk_alpha_g1_beta_g2)
+    if (QAP != vk_alpha_g1_beta_g2)
     {
         if (!libff::inhibit_profiling_info)
         {
@@ -661,6 +674,7 @@ bool r1cs_gg_ppzksnark_affine_verifier_weak_IC(const r1cs_gg_ppzksnark_verificat
         proof_g_C_precomp, pvk_vk_delta_g2_precomp,
         proof_g_A_precomp,  proof_g_B_precomp);
     const libff::GT<ppT> QAP = ppT::final_exponentiation(QAP_miller.unitary_inverse());
+    const libff::GT<ppT> vk_alpha_g1_beta_g2 = ppT::reduced_pairing(vk.alpha_g1, vk.beta_g2);
 
     if (QAP != vk.alpha_g1_beta_g2)
     {


### PR DESCRIPTION
This pull request implements slight modifications of Groth16 Verification Key and functions that use it. We need these modifications because in Zeth we use a precompiled contract of Ethereum that performs pairing checks and takes in input only elements of `G1` and `G2`, not `GT`.