### PR TITLE
Support forcing pow 2 domains

### DIFF
--- a/libsnark/reductions/r1cs_to_qap/r1cs_to_qap.hpp
+++ b/libsnark/reductions/r1cs_to_qap/r1cs_to_qap.hpp
@@ -41,14 +41,18 @@ namespace libsnark {
  * Instance map for the R1CS-to-QAP reduction.
  */
 template<typename FieldT>
-qap_instance<FieldT> r1cs_to_qap_instance_map(const r1cs_constraint_system<FieldT> &cs);
+qap_instance<FieldT> r1cs_to_qap_instance_map(
+    const r1cs_constraint_system<FieldT> &cs,
+    bool force_pow_2_domain=false);
 
 /**
  * Instance map for the R1CS-to-QAP reduction followed by evaluation of the resulting QAP instance.
  */
 template<typename FieldT>
-qap_instance_evaluation<FieldT> r1cs_to_qap_instance_map_with_evaluation(const r1cs_constraint_system<FieldT> &cs,
-                                                                         const FieldT &t);
+qap_instance_evaluation<FieldT> r1cs_to_qap_instance_map_with_evaluation(
+    const r1cs_constraint_system<FieldT> &cs,
+    const FieldT &t,
+    bool force_pow_2_domain=false);
 
 /**
  * Witness map for the R1CS-to-QAP reduction.
@@ -56,12 +60,14 @@ qap_instance_evaluation<FieldT> r1cs_to_qap_instance_map_with_evaluation(const r
  * The witness map takes zero knowledge into account when d1,d2,d3 are random.
  */
 template<typename FieldT>
-qap_witness<FieldT> r1cs_to_qap_witness_map(const r1cs_constraint_system<FieldT> &cs,
-                                            const r1cs_primary_input<FieldT> &primary_input,
-                                            const r1cs_auxiliary_input<FieldT> &auxiliary_input,
-                                            const FieldT &d1,
-                                            const FieldT &d2,
-                                            const FieldT &d3);
+qap_witness<FieldT> r1cs_to_qap_witness_map(
+    const r1cs_constraint_system<FieldT> &cs,
+    const r1cs_primary_input<FieldT> &primary_input,
+    const r1cs_auxiliary_input<FieldT> &auxiliary_input,
+    const FieldT &d1,
+    const FieldT &d2,
+    const FieldT &d3,
+    bool force_pow_2_domain=false);
 
 } // libsnark
 

--- a/libsnark/reductions/r1cs_to_qap/r1cs_to_qap.tcc
+++ b/libsnark/reductions/r1cs_to_qap/r1cs_to_qap.tcc
@@ -33,11 +33,16 @@ namespace libsnark {
  *   each A_i,B_i,C_i is expressed in the Lagrange basis.
  */
 template<typename FieldT>
-qap_instance<FieldT> r1cs_to_qap_instance_map(const r1cs_constraint_system<FieldT> &cs)
+qap_instance<FieldT> r1cs_to_qap_instance_map(
+    const r1cs_constraint_system<FieldT> &cs,
+    bool force_pow_2_domain)
 {
     libff::enter_block("Call to r1cs_to_qap_instance_map");
 
-    const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain = libfqfft::get_evaluation_domain<FieldT>(cs.num_constraints() + cs.num_inputs() + 1);
+    const size_t min_n = cs.num_constraints() + cs.num_inputs() + 1;
+    const size_t n = force_pow_2_domain ? 1 << libff::log2(min_n) : min_n;
+    std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain =
+        libfqfft::get_evaluation_domain<FieldT>(n);
 
     std::vector<std::map<size_t, FieldT> > A_in_Lagrange_basis(cs.num_variables()+1);
     std::vector<std::map<size_t, FieldT> > B_in_Lagrange_basis(cs.num_variables()+1);
@@ -102,12 +107,17 @@ qap_instance<FieldT> r1cs_to_qap_instance_map(const r1cs_constraint_system<Field
  *   n = degree of the QAP
  */
 template<typename FieldT>
-qap_instance_evaluation<FieldT> r1cs_to_qap_instance_map_with_evaluation(const r1cs_constraint_system<FieldT> &cs,
-                                                                         const FieldT &t)
+qap_instance_evaluation<FieldT> r1cs_to_qap_instance_map_with_evaluation(
+    const r1cs_constraint_system<FieldT> &cs,
+    const FieldT &t,
+    bool force_pow_2_domain)
 {
     libff::enter_block("Call to r1cs_to_qap_instance_map_with_evaluation");
 
-    const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain = libfqfft::get_evaluation_domain<FieldT>(cs.num_constraints() + cs.num_inputs() + 1);
+    const size_t min_n = cs.num_constraints() + cs.num_inputs() + 1;
+    const size_t n = force_pow_2_domain ? 1 << libff::log2(min_n) : min_n;
+    std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain =
+        libfqfft::get_evaluation_domain<FieldT>(n);
 
     std::vector<FieldT> At, Bt, Ct, Ht;
 
@@ -203,19 +213,24 @@ qap_instance_evaluation<FieldT> r1cs_to_qap_instance_map_with_evaluation(const r
  * some reshuffling to save space.
  */
 template<typename FieldT>
-qap_witness<FieldT> r1cs_to_qap_witness_map(const r1cs_constraint_system<FieldT> &cs,
-                                            const r1cs_primary_input<FieldT> &primary_input,
-                                            const r1cs_auxiliary_input<FieldT> &auxiliary_input,
-                                            const FieldT &d1,
-                                            const FieldT &d2,
-                                            const FieldT &d3)
+qap_witness<FieldT> r1cs_to_qap_witness_map(
+    const r1cs_constraint_system<FieldT> &cs,
+    const r1cs_primary_input<FieldT> &primary_input,
+    const r1cs_auxiliary_input<FieldT> &auxiliary_input,
+    const FieldT &d1,
+    const FieldT &d2,
+    const FieldT &d3,
+    bool force_pow_2_domain)
 {
     libff::enter_block("Call to r1cs_to_qap_witness_map");
 
     /* sanity check */
     assert(cs.is_satisfied(primary_input, auxiliary_input));
 
-    const std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain = libfqfft::get_evaluation_domain<FieldT>(cs.num_constraints() + cs.num_inputs() + 1);
+    const size_t min_n = cs.num_constraints() + cs.num_inputs() + 1;
+    const size_t n = force_pow_2_domain ? 1 << libff::log2(min_n) : min_n;
+    std::shared_ptr<libfqfft::evaluation_domain<FieldT> > domain =
+        libfqfft::get_evaluation_domain<FieldT>(n);
 
     r1cs_variable_assignment<FieldT> full_variable_assignment = primary_input;
     full_variable_assignment.insert(full_variable_assignment.end(), auxiliary_input.begin(), auxiliary_input.end());

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.hpp
@@ -359,10 +359,30 @@ public:
 /**
  * A generator algorithm for the R1CS GG-ppzkSNARK.
  *
+ * Given a R1CS constraint system CS and vaules for all secrets,
+ * produce the proving and verification keys for CS.  Optionally force
+ * the domain size
+ */
+template<typename ppT>
+r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator_from_secrets(
+    const r1cs_gg_ppzksnark_constraint_system<ppT> &cs,
+    const libff::Fr<ppT> &t,
+    const libff::Fr<ppT> &alpha,
+    const libff::Fr<ppT> &beta,
+    const libff::Fr<ppT> &delta,
+    const libff::G1<ppT> &g1_generator,
+    const libff::G2<ppT> &g2_generator,
+    bool force_pow_2_domain=false);
+
+/**
+ * A generator algorithm for the R1CS GG-ppzkSNARK.
+ *
  * Given a R1CS constraint system CS, this algorithm produces proving and verification keys for CS.
  */
 template<typename ppT>
-r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksnark_constraint_system<ppT> &cs);
+r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(
+    const r1cs_gg_ppzksnark_constraint_system<ppT> &cs,
+    bool force_pow_2_domain=false);
 
 /**
  * A prover algorithm for the R1CS GG-ppzkSNARK.
@@ -373,9 +393,11 @@ r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksna
  * Above, CS is the R1CS constraint system that was given as input to the generator algorithm.
  */
 template<typename ppT>
-r1cs_gg_ppzksnark_proof<ppT> r1cs_gg_ppzksnark_prover(const r1cs_gg_ppzksnark_proving_key<ppT> &pk,
-                                                      const r1cs_gg_ppzksnark_primary_input<ppT> &primary_input,
-                                                      const r1cs_gg_ppzksnark_auxiliary_input<ppT> &auxiliary_input);
+r1cs_gg_ppzksnark_proof<ppT> r1cs_gg_ppzksnark_prover(
+    const r1cs_gg_ppzksnark_proving_key<ppT> &pk,
+    const r1cs_gg_ppzksnark_primary_input<ppT> &primary_input,
+    const r1cs_gg_ppzksnark_auxiliary_input<ppT> &auxiliary_input,
+    bool force_pow_2_domain=false);
 
 /*
   Below are four variants of verifier algorithm for the R1CS GG-ppzkSNARK.

--- a/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
+++ b/libsnark/zk_proof_systems/ppzksnark/r1cs_gg_ppzksnark/r1cs_gg_ppzksnark.tcc
@@ -403,7 +403,7 @@ r1cs_gg_ppzksnark_keypair<ppT> r1cs_gg_ppzksnark_generator(const r1cs_gg_ppzksna
     r1cs_gg_ppzksnark_keypair<ppT> key_pair = r1cs_gg_ppzksnark_generator_from_secrets<ppT>(
         r1cs, t, alpha, beta, delta, g1_generator, g2_generator);
 
-    libff::enter_block("Call to r1cs_gg_ppzksnark_generator");
+    libff::leave_block("Call to r1cs_gg_ppzksnark_generator");
 
     return std::move(key_pair);
 }


### PR DESCRIPTION
By default, libsnark chooses a domain type and size based on the size of the constrainti system.

When using data from an MPC, first layer data is computed against a domain of a specific size (2^n for some n).  When this MPC data used for specific circuits to compute keys (and later proofs) for that circuit, a matching domain must be used.  This PR adds a `force_pow2_domain` flag in the appropriate places.  The flag defaults to `false` if not specified, so existing client code is not affected.