### PR TITLE
Prevent invalid copying of protoboard objcts

### DIFF
--- a/libsnark/gadgetlib1/protoboard.hpp
+++ b/libsnark/gadgetlib1/protoboard.hpp
@@ -68,6 +68,13 @@ public:
     friend class pb_linear_combination<FieldT>;
 
 private:
+    // The default copy constructor and assignment operator do not properly
+    // copy protoboard, rendering it unusable. The following prevents copying.
+    // It is unlikely to be the right thing to do (for performance reasons) and
+    // it causes subtle errors.
+    protoboard(const protoboard &);
+    const protoboard &operator=(const protoboard &);
+
     var_index_t allocate_var_index(const std::string &annotation="");
     lc_index_t allocate_lc_index();
 };


### PR DESCRIPTION
We sometimes see copying of protoboard objects (inadvisable, but can happen where memory management is overlooked). However protoboard does not implement working copying operators and the default operators are not sufficient, hence subtle errors can occur.  This change prevents this class of errors at compile-time.