### PR TITLE
Added --recursive flag to git submodule update

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ sudo yum install \
 Fetch dependencies from their GitHub repos:
 
 ```console
-git submodule init && git submodule update
+git submodule update --init --recursive
 ```
 
 Create the Makefile:


### PR DESCRIPTION
As per the title, this PR add the `--recursive` flag to the submodule command. The current README omits it which causes the following error when one wants to compile the project (e.g. run `make` or `make check`):
```console
CMake Error at depends/CMakeLists.txt:1 (add_subdirectory):
The source directory libsnark/depends/libff/depends/gtest does not contain a CMakeLists.txt file.
```

This is to be expected since gtest is part of libff's submodule, which itself is a submodule of libsnark, hence the need for the `--recursive` flag.