### PR TITLE
Annotation arguments + small build fixes (depends on #44)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,10 +133,12 @@ if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "^(Apple)?Clan
   endif()
   # Default optimizations flags (to override, use -DOPT_FLAGS=...)
   if("${OPT_FLAGS}" STREQUAL "")
-    set(
-      OPT_FLAGS
-      "-ggdb3 -O2 -march=native -mtune=native"
-    )
+    if (NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug"))
+      set(
+        OPT_FLAGS
+        "-ggdb3 -O2 -march=native -mtune=native"
+        )
+    endif()
   endif()
 endif()
 

--- a/libsnark/gadgetlib1/gadget.hpp
+++ b/libsnark/gadgetlib1/gadget.hpp
@@ -20,7 +20,7 @@ protected:
     const std::string annotation_prefix;
 
 public:
-    gadget(protoboard<FieldT> &pb, const std::string &annotation_prefix = "");
+    gadget(protoboard<FieldT> &pb, const std::string &annotation_prefix);
 };
 
 } // namespace libsnark

--- a/libsnark/gadgetlib1/gadget.tcc
+++ b/libsnark/gadgetlib1/gadget.tcc
@@ -16,6 +16,8 @@ gadget<FieldT>::gadget(
     protoboard<FieldT> &pb, const std::string &annotation_prefix)
     : pb(pb), annotation_prefix(annotation_prefix)
 {
+    // Annotations may appear as "" (even if set by the calling code) unless
+    // DEBUG is set. See pb_variable.tcc.
 #ifdef DEBUG
     assert(annotation_prefix != "");
 #endif

--- a/libsnark/gadgetlib1/pb_variable.hpp
+++ b/libsnark/gadgetlib1/pb_variable.hpp
@@ -94,17 +94,6 @@ public:
     FieldT get_field_element_from_bits(const protoboard<FieldT> &pb) const;
 };
 
-/// A utility function which creates and allocates a variable in a single step
-/// (and can therefore be used in initalizer lists, which greatly simplifies
-/// many constructors).
-///
-/// TODO: Why does pb_variable not have an allocating constructor of this form,
-/// even further simplifying a lot of code. Move this to an appropriate
-/// constructor if there are no issues.
-template<typename FieldT>
-pb_variable<FieldT> pb_variable_allocate(
-    protoboard<FieldT> &pb, const std::string &annotation);
-
 /* index 0 corresponds to the constant term (used in legacy code) */
 #define ONE pb_variable<FieldT>(0)
 

--- a/libsnark/gadgetlib1/pb_variable.hpp
+++ b/libsnark/gadgetlib1/pb_variable.hpp
@@ -26,7 +26,7 @@ template<typename FieldT> class pb_variable : public variable<FieldT>
 public:
     pb_variable(const var_index_t index = 0) : variable<FieldT>(index){};
 
-    void allocate(protoboard<FieldT> &pb, const std::string &annotation = "");
+    void allocate(protoboard<FieldT> &pb, const std::string &annotation);
 };
 
 /// A utility function which creates and allocates a variable in a single step
@@ -77,7 +77,7 @@ public:
     void allocate(
         protoboard<FieldT> &pb,
         const size_t n,
-        const std::string &annotation_prefix = "");
+        const std::string &annotation_prefix);
 
     void fill_with_field_elements(
         protoboard<FieldT> &pb, const std::vector<FieldT> &vals) const;

--- a/libsnark/gadgetlib1/pb_variable.tcc
+++ b/libsnark/gadgetlib1/pb_variable.tcc
@@ -28,6 +28,13 @@ void pb_variable_array<FieldT>::allocate(
     const size_t n,
     const std::string &annotation_prefix)
 {
+    // The DEBUG variable controls whether or not the FMT macro actually
+    // performs string concatenation or simply returns "". Therefore, even
+    // though gadget code may always set an annotation, it may appear as ""
+    // unless DEBUG is set.
+    //
+    // TODO: control annotations via a variable such as
+    // LIBSNARK_ENABLE_ANNOTATIONS.
 #ifdef DEBUG
     assert(annotation_prefix != "");
 #endif


### PR DESCRIPTION
Along with some small build issues, fixes the mismatch between asserts on variable annotations (e.g. `assert(annotation != "")`) and the default parameters (e.g. `annotation = ""`) which is highly confusing and can cause annoying errors. 

Partially addresses issue #21.