### PR TITLE
69 plonk remove domain from srs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ set(
   "BN128"
   CACHE
   STRING
-  "Default curve: one of ALT_BN128, BN128, EDWARDS, MNT4, MNT6, BLS12_381"
+  "Default curve: one of ALT_BN128, BN128, EDWARDS, MNT4, MNT6, BW6_761, BLS12_377, BLS12_381"
 )
 
 option(

--- a/libsnark/zk_proof_systems/plonk/prover.hpp
+++ b/libsnark/zk_proof_systems/plonk/prover.hpp
@@ -273,6 +273,7 @@ public:
         const std::vector<libff::Fr<ppT>> &blind_scalars,
         const std::vector<libff::Fr<ppT>> &witness,
         const srs<ppT> &srs,
+        std::shared_ptr<libfqfft::evaluation_domain<libff::Fr<ppT>>> domain,
         transcript_hasher &hasher);
 
     /// Prover Round 2
@@ -299,6 +300,7 @@ public:
         const std::vector<libff::Fr<ppT>> blind_scalars,
         const std::vector<libff::Fr<ppT>> &witness,
         const srs<ppT> &srs,
+        std::shared_ptr<libfqfft::evaluation_domain<libff::Fr<ppT>>> domain,
         transcript_hasher &hasher);
 
     /// Prover Round 3

--- a/libsnark/zk_proof_systems/plonk/prover.hpp
+++ b/libsnark/zk_proof_systems/plonk/prover.hpp
@@ -236,35 +236,26 @@ public:
     ///
     /// INPUT
     /// \param[in] srs: structured reference string containing also
-    /// circuit-specific
-    ///   information
+    ///            circuit-specific information
     ///
     /// OUTPUT
-    /// \param[out] W_polys: Lagrange interpolation of the witness values
-    /// \param[out] zh_poly: vanishing polynomial
-    /// \param[out] null_poly: 0 polynomial
-    /// \param[out] neg_one_poly: -1 polynomial
+    /// \param[out] round_zero_out_t
     static round_zero_out_t<ppT> round_zero(const srs<ppT> &srs);
 
     /// Prover Round 1
     ///
     /// INPUT
-    /// \param[in] zh_poly: vanishing polynomial Zh (from round 0)
-    /// \param[in] null_poly: 0 polynomial (from round 0)
-    /// \param[in] neg_one_poly: -1 polynomial (from round 0)
+    /// \param[in] round_zero_out: see round_zero_out_t
     /// \param[in] blind_scalars: blinding scalars b1, b2, ..., b9 (only
-    ///            b1-b6 used in round 1)
+    ///            b1-b6 used in round 1) (see Sect. 8.1, Round 1 in [GWC19])
     /// \param[in] witness: witness values
     /// \param[in] srs: structured reference string containing also
     ///            circuit-specific information
+    /// \param[in] domain: libfqfft evaluation domain (see
+    ///            libfqfft/evaluation_domain/evaluation_domain.hpp)
     ///
     /// OUTPUT
-    /// \param[out] W_polys: witness polynomials (Lagrange interpolation
-    ///             of the witness values)
-    /// \param[out] W_polys_blinded: blinded witness polynomials
-    /// \param[out] W_polys_blinded_at_secret_g1: the blinded witness
-    ///             polynomials evaluated at the secret input denoted
-    ///             [a]_1, [b]_1, [c]_1 in [GWC19]
+    /// \param[out] round_one_out: see round_one_out_t
     /// \param[out] transcript_hasher: accumulates the communication
     ///             transcript into a buffer to be hashed after prover
     ///             rounds 1,2,3,4,5 (cf. fiat-shamir heuristic).
@@ -279,17 +270,19 @@ public:
     /// Prover Round 2
     ///
     /// INPUT
-    /// \param[in] zh_poly: vanishing polynomial Zh (from round 0)
+    /// \param[in] beta, gamma: permutation challenges -- hashes of
+    ///            transcript (from round 2)
+    /// \param[in] round_zero_out: see round_zero_out_t
     /// \param[in] blind_scalars: blinding scalars b1, b2, ..., b9 (only
-    ///            b7,b8,b9 used in round 2)
+    ///            b1-b6 used in round 1) (see Sect. 8.1, Round 1 in [GWC19])
     /// \param[in] witness: witness values
     /// \param[in] srs: structured reference string containing also
     ///            circuit-specific information
+    /// \param[in] domain: libfqfft evaluation domain (see
+    ///            libfqfft/evaluation_domain/evaluation_domain.hpp)
     ///
     /// OUTPUT
-    /// \param[out] z_poly: blinded accumulator poly z(x)
-    /// \param[out] z_poly_at_secret_g1: blinded accumulator poly z(x)
-    ///             evaluated at secret
+    /// \param[out] round_two_out: see round_two_out_t
     /// \param[out] transcript_hasher: accumulates the communication
     ///             transcript into a buffer to be hashed after prover
     ///             rounds 1,2,3,4,5 (cf. fiat-shamir heuristic).
@@ -306,24 +299,18 @@ public:
     /// Prover Round 3
     ///
     /// INPUT
-    /// \param[in] zh_poly: vanishing polynomial Zh (from Round 0)
-    /// \param[in] W_polys_blinded: blinded witness polynomials (from
-    ///            Round 1)
+    /// \param[in] alpha: quotient challenge -- hash of transcript (from
+    ///            round 3)
     /// \param[in] beta, gamma: permutation challenges -- hashes of
     ///            transcript (from round 2)
-    /// \param[in] z_poly: blinded accumulator poly z(x) (from Round 2)
+    /// \param[in] round_zero_out: see round_zero_out_t
+    /// \param[in] round_one_out: see round_one_out_t
+    /// \param[in] round_two_out: see round_two_out_t
     /// \param[in] srs: structured reference string containing also
     ///            circuit-specific information
     ///
     /// OUTPUT
-    /// \param[out] t_poly_long: the quotient polynomial t(x) (see Round
-    ///             3, pp28 [GWC19])
-    /// \param[out] t_poly: t(x) divided in three parts t(x) = t_lo(x) +
-    ///             t_mid(x) x^n + t_hi(x) x^{2n}
-    /// \param[out] t_poly_at_secret_g1: t(x) evaluated at the secret
-    ///             input zeta i.e. t(zeta)
-    /// \param[out] z_poly_xomega: the polynomial z(x*w) i.e. z(x) shifted
-    ///             by w
+    /// \param[out] round_three_out: see round_three_out_t
     /// \param[out] transcript_hasher: accumulates the communication
     ///             transcript into a buffer to be hashed after prover
     ///             rounds 1,2,3,4,5 (cf. fiat-shamir heuristic).
@@ -340,34 +327,15 @@ public:
     /// Prover Round 4
     ///
     /// INPUT
-    /// \param[in] W_polys_blinded: blinded witness polynomials (from
-    ///            Round 1)
-    /// \param[in] z_poly_xomega: the polynomial z(x*w) i.e. z(x) shifted
-    ///            by w (from Round 3)
-    /// \param[in] t_poly_long: the quotient polynomial t(x) (see Round 3,
-    ///            pp28 [GWC19]) (from Round 3)
+    /// \param[in] zeta: evaluation challenge -- hash of transcript (from
+    ///            round 4)
+    /// \param[in] round_one_out: see round_one_out_t
+    /// \param[in] round_three_out: see round_three_out_t
     /// \param[in] srs: structured reference string containing also
     ///            circuit-specific information
     ///
     /// OUTPUT
-    /// \param[out] a_zeta, b_zeta, c_zeta: the blinded witness
-    ///             polynomials a(x), b(x), c(x) (denoted by
-    ///             W_polys_blinded[] output from Round 1) evaluated at
-    ///             x=zeta i.e. a(z), b(z), c(z)
-    /// \param[out] S_0_zeta, S_1_zeta: the permutation polynomials
-    ///             S_sigma_1(x), S_sigma_2(x) from the common
-    ///             preprocessed input (see [GWC19], Sect. 8.1) evaluated
-    ///             at x=zeta i.e. S_sigma_1(z), S_sigma_2(z)
-    /// \param[out] z_poly_xomega_zeta: the polynomial z(x*w) i.e. z(x)
-    ///             shifted by w (output from Round 3) evaluated at x=zeta
-    ///             i.e. z(zeta*w)
-    /// \param[out] t_zeta: the quotient polynomial t(x) output from Round
-    ///             3, see pp28 [GWC19]) evaluated at x=zeta
-    ///             i.e. t(z). IMPORTANT! the original Plonk proposal
-    ///             [GWC19] does not output this parameter t_zeta. The
-    ///             Python reference implementation does, so we do the
-    ///             same in order to match the test vectors. TODO can
-    ///             remove t_zeta in the future
+    /// \param[out] round_four_out: see round_four_out_t
     /// \param[out] transcript_hasher: accumulates the communication
     ///             transcript into a buffer to be hashed after prover
     ///             rounds 1,2,3,4,5 (cf. fiat-shamir heuristic).
@@ -381,47 +349,24 @@ public:
     /// Prover Round 5
     ///
     /// INPUT
-    /// \param[in] beta, gamma: permutation challenges -- hashes of
-    ///            transcript (from round 2)
     /// \param[in] alpha: quotient challenge -- hash of transcript (from
     ///            round 3)
+    /// \param[in] beta, gamma: permutation challenges -- hashes of
+    ///            transcript (from round 2)
     /// \param[in] zeta: evaluation challenge -- hash of transcript (from
     ///            round 4)
-    /// \param[in] a_zeta, b_zeta, c_zeta: the blinded witness polynomials
-    ///            a(x), b(x), c(x) (denoted by W_polys_blinded[] output
-    ///            from Round 1) evaluated at x=zeta i.e. a(z), b(z), c(z)
-    ///            (from round 4)
-    /// \param[in] S_0_zeta, S_1_zeta: the permutation polynomials
-    ///            S_sigma_1(x), S_sigma_2(x) from the common preprocessed
-    ///            input (see [GWC19], Sect. 8.1) evaluated at x=zeta
-    ///            i.e. S_sigma_1(z), S_sigma_2(z) (from round 4)
-    /// \param[in] t_zeta: the quotient polynomial t(x) output from Round
-    ///            3, see pp28 [GWC19]) evaluated at x=zeta
-    ///            i.e. t(z). IMPORTANT! the original Plonk proposal
-    ///            [GWC19] does not output this parameter t_zeta. The
-    ///            Python reference implementation does, so we do the same
-    ///            in order to match the test vectors. TODO can remove
-    ///            t_zeta in the future (from round 4)
-    /// \param[in] z_poly_xomega_zeta: the polynomial z(x*w) i.e. z(x)
-    ///            shifted by w (output from Round 3) evaluated at x=zeta
-    ///            i.e. z(zeta*w) (from round 4)
-    /// \param[in] W_polys_blinded: blinded witness polynomials (from
-    ///            round 1)
-    /// \param[in] t_poly: t(x) divided in three parts t(x) = t_lo(x) +
-    ///            t_mid(x) x^n + t_hi(x) x^{2n} (from round 3)
-    /// \param[in] z_poly: blinded accumulator poly z(x) (from round 2)
+    /// \param[in] nu: opening challenge -- hash of transcript (from round 5)
+    ///            (denoted by v in [GWC19])
+    /// \param[in] round_zero_out: see round_zero_out_t
+    /// \param[in] round_one_out: see round_one_out_t
+    /// \param[in] round_two_out: see round_two_out_t
+    /// \param[in] round_three_out: see round_three_out_t
+    /// \param[in] round_four_out: see round_four_out_t
     /// \param[in] srs: structured reference string containing also
     ///            circuit-specific information
     ///
     /// OUTPUT
-    /// \param[out] r_zeta: linearisation polynomial r(x) evaluated at
-    ///             x=zeta ie. r(zeta)
-    /// \param[out] W_zeta_at_secret: commitment to opening proof
-    ///             polynomial W_zeta(x) at secert input
-    ///             i.e. [W_zeta(secret)]_1
-    /// \param[out] W_zeta_omega_at_secret: commitment to opening proof
-    ///             polynomial W_{zeta omega}(x) at secert input
-    ///             i.e. [W_{zeta omega}(secret)]_1
+    /// \param[out] round_five_out: see round_five_out_t
     /// \param[out] transcript_hasher: accumulates the communication
     ///             transcript into a buffer to be hashed after prover
     ///             rounds 1,2,3,4,5 (cf. fiat-shamir heuristic).
@@ -452,13 +397,13 @@ public:
     /// evaluation of the linearlization polynomial r(X) at zeta from
     /// Prover round 5) is added to the pi-SNARK proof. In the paper this
     /// is omitted, which seems to make the proof shorter by 1 element at
-    /// the epxense of a slightly heavier computation on the verifier's
+    /// the expense of a slightly heavier computation on the verifier's
     /// side. Here we follow the reference implementation to make sure we
     /// match the test values. TODO: once all test vectors are verified,
     /// we may remove r_zeta from the proof to be fully compliant with the
     /// paper.
     ///
-    /// Mapping code-to-paper quantities
+    /// Mapping code-to-paper quantities (format is 'code var : paper var')
     ///
     /// \param W_polys_blinded_at_secret_g1[a, b, c]: [a]_1, [b]_1, [c]_1
     ///        (from Round 1)
@@ -477,7 +422,7 @@ public:
     /// \param[in] witness: all internal values and public input
     ///            corresponding to the given circuit
     /// \param[in] blind_scalars: random blinding scalars b1, b2, ..., b9
-    ///            used in prover rounds 1 and 2 (see Sect. 8.3, roumds
+    ///            used in prover rounds 1 and 2 (see Sect. 8.3, rounds
     ///            1,2 [GWC19])
     /// \param[in] transcript_hasher: hashes of the communication
     ///            transcript after prover rounds 1,2,3,4,5.

--- a/libsnark/zk_proof_systems/plonk/srs.hpp
+++ b/libsnark/zk_proof_systems/plonk/srs.hpp
@@ -124,9 +124,6 @@ public:
     /// the 0-th polynomial of the Lagrange basis
     polynomial<Field> L_basis_zero;
 
-    /// the libfqfft domain
-    std::shared_ptr<libfqfft::evaluation_domain<Field>> domain;
-
     srs(const size_t &num_gates,
         const size_t &num_qpolys,
         const polynomial<Field> &PI_poly,
@@ -139,8 +136,7 @@ public:
         const libff::Fr<ppT> &k2,
         std::vector<libff::G1<ppT>> &&secret_powers_g1,
         std::vector<libff::G2<ppT>> &&secret_powers_g2,
-        const polynomial<Field> &L_basis_zero,
-        std::shared_ptr<libfqfft::evaluation_domain<Field>> domain);
+        const polynomial<Field> &L_basis_zero);
 };
 
 /// Derive the (plain) SRS from the circuit description and the

--- a/libsnark/zk_proof_systems/plonk/srs.tcc
+++ b/libsnark/zk_proof_systems/plonk/srs.tcc
@@ -37,8 +37,7 @@ srs<ppT>::srs(
     const libff::Fr<ppT> &k2,
     std::vector<libff::G1<ppT>> &&secret_powers_g1,
     std::vector<libff::G2<ppT>> &&secret_powers_g2,
-    const polynomial<Field> &L_basis_zero,
-    std::shared_ptr<libfqfft::evaluation_domain<libff::Fr<ppT>>> domain)
+    const polynomial<Field> &L_basis_zero)
     : num_gates(num_gates)
     , num_qpolys(num_qpolys)
     , PI_poly(PI_poly)
@@ -52,7 +51,6 @@ srs<ppT>::srs(
     , secret_powers_g1(secret_powers_g1)
     , secret_powers_g2(secret_powers_g2)
     , L_basis_zero(L_basis_zero)
-    , domain(domain)
 {
 }
 
@@ -145,8 +143,7 @@ srs<ppT> plonk_srs_derive_from_usrs(
         circuit.k2,
         std::move(secret_powers_g1),
         std::move(secret_powers_g2),
-        std::move(L_basis_zero),
-        domain);
+        std::move(L_basis_zero));
 
     return srs;
 }

--- a/libsnark/zk_proof_systems/plonk/utils.hpp
+++ b/libsnark/zk_proof_systems/plonk/utils.hpp
@@ -56,6 +56,8 @@ template<typename FieldT> void print_vector(const std::vector<FieldT> &v);
 /// \param[in] f_points[0..n-1]: a set of points (0,y0), (1,y1),
 ///            ... (n-1,y_{n-1}) s.t. y0=f_points[0], y1=f_points[1],
 ///            ... which we want to interpolate as a polynomial
+/// \param[in] domain: libfqfft evaluation domain (see
+///            libfqfft/evaluation_domain/evaluation_domain.hpp)
 ///
 /// OUTPUT:
 ///

--- a/libsnark/zk_proof_systems/plonk/utils.hpp
+++ b/libsnark/zk_proof_systems/plonk/utils.hpp
@@ -70,7 +70,9 @@ template<typename FieldT> void print_vector(const std::vector<FieldT> &v);
 /// \note uses libfqfft iFFT for the interpolation
 template<typename FieldT>
 void plonk_interpolate_polynomial_from_points(
-    const std::vector<FieldT> &f_points, polynomial<FieldT> &f_poly);
+    const std::vector<FieldT> &f_points,
+    polynomial<FieldT> &f_poly,
+    std::shared_ptr<libfqfft::evaluation_domain<FieldT>> domain);
 
 /// Compute the selector polynomials of the given circuit (also
 /// called here "q-polynomials"). See Sect. 8.1.  The matrix
@@ -80,7 +82,8 @@ void plonk_interpolate_polynomial_from_points(
 template<typename FieldT>
 std::vector<polynomial<FieldT>> plonk_compute_selector_polynomials(
     const size_t &num_gates,
-    const std::vector<std::vector<FieldT>> &gates_matrix_transpose);
+    const std::vector<std::vector<FieldT>> &gates_matrix_transpose,
+    std::shared_ptr<libfqfft::evaluation_domain<FieldT>> domain);
 
 /// This function computes the sets H, k1H, k2H.  H is a
 /// multiplicative subgroup containing the n-th roots of unity in Fr,
@@ -124,7 +127,9 @@ std::vector<FieldT> plonk_permute_subgroup_H(
 /// S_sigma_2 (see [GWC19], Sect. 8.1)
 template<typename FieldT>
 std::vector<polynomial<FieldT>> plonk_compute_permutation_polynomials(
-    const std::vector<FieldT> &H_gen_permute, const size_t num_gates);
+    const std::vector<FieldT> &H_gen_permute,
+    const size_t num_gates,
+    std::shared_ptr<libfqfft::evaluation_domain<FieldT>> domain);
 
 // A wrapper for multi_exp_method_BDLO12_signed() dot-product a
 // vector of group elements in G1 (curve points) with a vector of

--- a/libsnark/zk_proof_systems/plonk/verifier.hpp
+++ b/libsnark/zk_proof_systems/plonk/verifier.hpp
@@ -213,7 +213,8 @@ public:
     /// \param[out] zh_zeta: evaluation of vanishing polynomial Zh at
     ///             x=zeta i.e. Zh(zeta)
     static step_five_out_t<ppT> step_five(
-        const step_four_out_t<ppT> &step_four_out, const srs<ppT> &srs);
+        const step_four_out_t<ppT> &step_four_out,
+        std::shared_ptr<libfqfft::evaluation_domain<libff::Fr<ppT>>> domain);
 
     /// Verifier Step 6: Compute Lagrange polynomial evaluation L1(zeta)
     /// Note: the paper counts the L-polynomials from 1; we count from 0


### PR DESCRIPTION
Removed the `domain` from the `srs` as it is not used. Addresses Issue #69 .