### PR TITLE
90 plonk setting k1 k2

### DIFF
--- a/libsnark/zk_proof_systems/plonk/srs.tcc
+++ b/libsnark/zk_proof_systems/plonk/srs.tcc
@@ -70,7 +70,7 @@ template<typename ppT>
 usrs<ppT> plonk_usrs_derive_from_secret(
     const libff::Fr<ppT> &secret, const size_t max_degree)
 {
-    // compute powers of secret times G1: 1*G1, secret^1*G1, secret^2*G1, ...
+    // Compute powers of secret times G1: 1*G1, secret^1*G1, secret^2*G1, ...
     const libff::bigint<libff::Fr<ppT>::num_limbs> secret_bigint =
         secret.as_bigint();
     const size_t window_size = std::max(
@@ -90,7 +90,7 @@ usrs<ppT> plonk_usrs_derive_from_secret(
         secret_powers_g1.push_back(secret_i_g1);
     }
 
-    // compute powers of secret times G2: 1*G2, secret^1*G2
+    // Compute powers of secret times G2: 1*G2, secret^1*G2.
     // Note: in Plonk we *always* have 2 encoded elemnts in G2
     std::vector<libff::G2<ppT>> secret_powers_g2;
     secret_powers_g2.reserve(2);
@@ -115,28 +115,28 @@ srs<ppT> plonk_srs_derive_from_usrs(
     const std::vector<std::vector<Field>> gates_matrix_transpose =
         plonk_gates_matrix_transpose(gates_matrix);
 
-    // the number of gates is equal to the number of columns in the transposed
-    // gates matrix
+    // The number of gates is equal to the number of columns in the
+    // transposed gates matrix.
     size_t num_gates = gates_matrix_transpose[0].size();
-    // ensure that num_gates is not 0
+    // Ensure that num_gates is not 0.
     assert(num_gates > 0);
-    // ensure num_gates is power of 2
+    // Ensure num_gates is power of 2.
     assert((num_gates & (num_gates - 1)) == 0);
 
-    // the number of Q-polynomials (aka selector polynomials) is equal to the
-    // number of rows in the transposed gates matrix
+    // The number of Q-polynomials (aka selector polynomials) is equal
+    // to the number of rows in the transposed gates matrix.
     size_t num_qpolys = gates_matrix_transpose.size();
 
-    // the constraints q_L, q_R, q_O, q_M, q_C and the
+    // The constraints q_L, q_R, q_O, q_M, q_C and the
     // witness w_L, w_R, w_O are represented as polynomials in the roots of
-    // unity e.g. f_{q_L}(omega_i) = q_L[i], 0\le{i}<8
+    // unity e.g. f_{q_L}(omega_i) = q_L[i], 0\le{i}<8.
     std::shared_ptr<libfqfft::evaluation_domain<Field>> domain =
         libfqfft::get_evaluation_domain<Field>(num_gates);
 
-    // compute the selector polynomials (q-polynomials) from the
+    // Compute the selector polynomials (q-polynomials) from the
     // transposed gates matrix over the Lagrange basis q_poly = \sum_i
     // q[i] * L[i] where q[i] is a coefficient (a scalar Field
-    // element) and L[i] is a polynomial with Field coefficients
+    // element) and L[i] is a polynomial with Field coefficients.
     std::vector<polynomial<Field>> Q_polys =
         plonk_compute_selector_polynomials<Field>(
             num_gates, num_qpolys, gates_matrix_transpose, domain);
@@ -202,7 +202,7 @@ srs<ppT> plonk_srs_derive_from_usrs(
     // TODO: write unit test for plonk_compute_cosets_H_k1H_k2H
     // assert(H_prime[i] == example.H_prime[i]);
 
-    // permute H_prime according to the wire permutation
+    // Permute H_prime according to the wire permutation.
     std::vector<Field> H_prime_permute =
         plonk_permute_subgroup_H<Field>(H_prime, wire_permutation, num_gates);
 
@@ -210,7 +210,7 @@ srs<ppT> plonk_srs_derive_from_usrs(
     // assert(H_prime_permute[i] == example.H_prime_permute[i]);
 
     // Compute the permutation polynomials S_sigma_1, S_sigma_2,
-    // S_sigma_3 (see [GWC19], Sect. 8.1) (our indexing starts from 0)
+    // S_sigma_3 (see [GWC19], Sect. 8.1) (our indexing starts from 0).
     std::vector<polynomial<Field>> S_polys =
         plonk_compute_permutation_polynomials<Field>(
             H_prime_permute, num_gates, domain);
@@ -230,7 +230,7 @@ srs<ppT> plonk_srs_derive_from_usrs(
         secret_powers_g2.push_back(usrs.secret_powers_g2[i]);
     }
 
-    // compute 0-th Lagrange basis vector via inverse FFT
+    // Compute 0-th Lagrange basis vector via inverse FFT.
     polynomial<libff::Fr<ppT>> L_basis_zero(num_gates, libff::Fr<ppT>(0));
     L_basis_zero[0] = libff::Fr<ppT>(1);
     domain->iFFT(L_basis_zero);

--- a/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
+++ b/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
@@ -1127,14 +1127,14 @@ template<typename ppT> void test_plonk_constants_k1_k2_bls12_381()
     using Field = libff::Fr<ppT>;
     Field k1, k2;
 
-    // check that the example k1 and k2 are valid (according to
+    // Check that the example k1 and k2 are valid (according to
     // plonk_are_valid_constants_k1_k2)"
     plonk_example example;
     k1 = example.k1;
     k2 = example.k2;
     ASSERT_TRUE(plonk_are_valid_constants_k1_k2(k1, k2));
 
-    // check that plonk_are_valid_constants_k1_k2 correctly detects
+    // Check that plonk_are_valid_constants_k1_k2 correctly detects
     // invalid combinations of k1 and k2
     for (size_t i = 1; i <= example.num_gates; ++i) {
         size_t ipower = i;
@@ -1156,7 +1156,7 @@ template<typename ppT> void test_plonk_constants_k1_k2_bls12_381()
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
     }
 
-    // check that plonk_generate_constants_k1_k2 generates valid k1
+    // Check that plonk_generate_constants_k1_k2 generates valid k1
     // and k2
     k1 = 0;
     k2 = 0;

--- a/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
+++ b/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
@@ -1092,13 +1092,13 @@ template<typename ppT> void test_plonk_constants_k1_k2()
     using Field = libff::Fr<ppT>;
     Field k1, k2;
     // n = 2^s
-    const size_t n = std::pow(2, k1.s);
+    //    const size_t n = std::pow(2, Field::s);
     bool b_valid = false;
     // load k1,k2 from example circuit
     plonk_example example;
     k1 = example.k1;
     k2 = example.k2;
-    b_valid = plonk_are_valid_constants_k1_k2(n, k1, k2);
+    b_valid = plonk_are_valid_constants_k1_k2(k1, k2);
     ASSERT_TRUE(b_valid);
     // check invalid k1,k2
     for (size_t i = 1; i <= example.num_gates; ++i) {
@@ -1106,22 +1106,22 @@ template<typename ppT> void test_plonk_constants_k1_k2()
         // invalid k2=k1*(omega^i)
         k1 = example.k1;
         k2 = k1 * (example.omega_base ^ ipower);
-        b_valid = plonk_are_valid_constants_k1_k2(n, k1, k2);
+        b_valid = plonk_are_valid_constants_k1_k2(k1, k2);
         ASSERT_FALSE(b_valid);
         // invalid k1=k2*(omega^i)
         k2 = example.k2;
         k1 = k2 * (example.omega_base ^ ipower);
-        b_valid = plonk_are_valid_constants_k1_k2(n, k1, k2);
+        b_valid = plonk_are_valid_constants_k1_k2(k1, k2);
         ASSERT_FALSE(b_valid);
         // invalid k1=omega^i
         k1 = (example.omega_base ^ ipower);
         k2 = example.k2;
-        b_valid = plonk_are_valid_constants_k1_k2(n, k1, k2);
+        b_valid = plonk_are_valid_constants_k1_k2(k1, k2);
         ASSERT_FALSE(b_valid);
         // invalid k2=omega^i
         k1 = example.k1;
         k2 = (example.omega_base ^ ipower);
-        b_valid = plonk_are_valid_constants_k1_k2(n, k1, k2);
+        b_valid = plonk_are_valid_constants_k1_k2(k1, k2);
         ASSERT_FALSE(b_valid);
     }
     // generate new k1,k2 and assert they are valid for a random
@@ -1130,8 +1130,8 @@ template<typename ppT> void test_plonk_constants_k1_k2()
     for (size_t i = 0; i < ntests; ++i) {
         k1 = 0;
         k2 = 0;
-        plonk_generate_constants_k1_k2(n, k1, k2);
-        b_valid = plonk_are_valid_constants_k1_k2(n, k1, k2);
+        plonk_generate_constants_k1_k2(k1, k2);
+        b_valid = plonk_are_valid_constants_k1_k2(k1, k2);
         // printf("k1 "); k1.print(); printf("k2 "); k2.print();
         ASSERT_TRUE(b_valid);
     }

--- a/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
+++ b/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
@@ -1115,13 +1115,16 @@ template<typename ppT> void test_plonk_constants_k1_k2_bls12_381()
 
     using Field = libff::Fr<ppT>;
     Field k1, k2;
-    // load k1,k2 from example circuit
+
+    // check that the example k1 and k2 are valid (according to
+    // plonk_are_valid_constants_k1_k2)"
     plonk_example example;
     k1 = example.k1;
     k2 = example.k2;
     ASSERT_TRUE(plonk_are_valid_constants_k1_k2(k1, k2));
-    // check invalid values for k1,k2 by setting one of them to be
-    // equal to an element of H, k1H or k2H
+
+    // check that plonk_are_valid_constants_k1_k2 correctly detects
+    // invalid combinations of k1 and k2
     for (size_t i = 1; i <= example.num_gates; ++i) {
         size_t ipower = i;
         // set k2 to an element of k1H:  k2=k1*(omega^i)
@@ -1141,8 +1144,9 @@ template<typename ppT> void test_plonk_constants_k1_k2_bls12_381()
         k2 = (example.omega_base ^ ipower);
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
     }
-    // generate new k1,k2 and assert they are valid for a random
-    // number of tests
+
+    // check that plonk_generate_constants_k1_k2 generates valid k1
+    // and k2
     k1 = 0;
     k2 = 0;
     plonk_generate_constants_k1_k2(k1, k2);

--- a/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
+++ b/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
@@ -1109,18 +1109,17 @@ template<typename ppT> void test_plonk_constants_k1_k2()
     ASSERT_TRUE(plonk_are_valid_constants_k1_k2(k1, k2));
 
     // Store the valid choices for k1,k2.
-    Field k1_valid = k1;
-    Field k2_valid = k2;
+    const Field k1_valid = k1;
+    const Field k2_valid = k2;
     // Example value for the number of gates (must be power of 2).
-    size_t num_gates = 8;
+    const size_t num_gates = 8;
     // Generate the n-th root of unity used as a generator of the
     // multiplicative group H of size num_gates.
-    Field omega_base = libff::get_root_of_unity<Field>(num_gates);
+    const Field omega_base = libff::get_root_of_unity<Field>(num_gates);
 
     // Check that plonk_are_valid_constants_k1_k2 correctly detects
     // invalid combinations of k1 and k2.
-    for (size_t i = 1; i <= num_gates; ++i) {
-        size_t ipower = i;
+    for (size_t ipower = 1; ipower <= num_gates; ++ipower) {
         // Set k2 to an element of k1H:  k2=k1*(omega^i).
         k1 = k1_valid;
         k2 = k1 * (omega_base ^ ipower);

--- a/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
+++ b/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
@@ -32,7 +32,7 @@ namespace libsnark
 #define PLONK_MAX_DEGREE 245
 
 // Manipulate elements of a valid proof to assert that proof
-// verification fails
+// verification fails.
 //
 // Plonk proof Pi is composed of the following elements:
 //
@@ -305,7 +305,7 @@ void test_plonk_prover_round_four(
     round_four_out_t<ppT> round_four_out =
         plonk_prover<ppT, transcript_hasher>::round_four(
             zeta, round_one_out, round_three_out, srs, hasher);
-    // Prover Round 4 output check against test vectors
+    // Prover Round 4 output check against test vectors.
     printf("[%s:%d] Output from Round 4\n", __FILE__, __LINE__);
     printf("a_zeta ");
     round_four_out.a_zeta.print();
@@ -381,14 +381,14 @@ void test_plonk_prover_round_five(
 }
 
 /// \attention the example class is defined specifically for the BLS12-381
-/// curve, so make sure we are using this curve
+/// curve, so make sure we are using this curve.
 template<typename ppT, class transcript_hasher> void test_plonk_prover_rounds()
 {
     using Field = libff::Fr<ppT>;
 
     ppT::init_public_params();
 
-    // load test vector values from example circuit
+    // Load test vector values from example circuit.
     plonk_example example;
     // random hidden element secret (toxic waste)
     Field secret = example.secret;
@@ -420,20 +420,20 @@ template<typename ppT, class transcript_hasher> void test_plonk_prover_rounds()
         plonk_prover<ppT, transcript_hasher>::round_zero(srs);
 
     // --- Unit test Prover Round 1 ---
-    // reset buffer at the start of the round (needed for testing only)
+    // Reset buffer at the start of the round (needed for testing only).
     printf("[%s:%d] Unit test Prover Round 1...\n", __FILE__, __LINE__);
     test_plonk_prover_round_one<ppT, transcript_hasher>(
         example, round_zero_out, witness, srs, domain, hasher);
 
     // --- Unit test Prover Round 2 ---
-    // reset buffer at the start of the round (needed for testing only)
+    // Reset buffer at the start of the round (needed for testing only).
     printf("[%s:%d] Unit test Prover Round 2...\n", __FILE__, __LINE__);
     round_one_out_t<ppT> round_one_out =
         plonk_prover<ppT, transcript_hasher>::round_one(
             round_zero_out, blind_scalars, witness, srs, domain, hasher);
     // clear hash buffer
     hasher.buffer_clear();
-    // add outputs from Round 1 to the hash buffer
+    // Add outputs from Round 1 to the hash buffer.
     hasher.add_element(round_one_out.W_polys_blinded_at_secret_g1[a]);
     hasher.add_element(round_one_out.W_polys_blinded_at_secret_g1[b]);
     hasher.add_element(round_one_out.W_polys_blinded_at_secret_g1[c]);
@@ -456,7 +456,7 @@ template<typename ppT, class transcript_hasher> void test_plonk_prover_rounds()
         example, beta, gamma, witness, srs, domain);
 
     // --- Unit test Prover Round 3 ---
-    // reset buffer at the start of the round (needed for testing only)
+    // Reset buffer at the start of the round (needed for testing only).
     printf("[%s:%d] Prover Round 3...\n", __FILE__, __LINE__);
     round_two_out_t<ppT> round_two_out =
         plonk_prover<ppT, transcript_hasher>::round_two(
@@ -468,14 +468,14 @@ template<typename ppT, class transcript_hasher> void test_plonk_prover_rounds()
             srs,
             domain,
             hasher);
-    // clear hash buffer
+    // Clear hash buffer.
     hasher.buffer_clear();
-    // add outputs from Round 1 to the hash buffer
+    // Add outputs from Round 1 to the hash buffer.
     hasher.add_element(round_one_out.W_polys_blinded_at_secret_g1[a]);
     hasher.add_element(round_one_out.W_polys_blinded_at_secret_g1[b]);
     hasher.add_element(round_one_out.W_polys_blinded_at_secret_g1[c]);
     hasher.add_element(libff::Fr<ppT>::one());
-    // add outputs from Round 2 to the hash buffer
+    // Add outputs from Round 2 to the hash buffer.
     hasher.add_element(round_two_out.z_poly_at_secret_g1);
     const libff::Fr<ppT> alpha = hasher.get_hash();
     test_plonk_prover_round_three<ppT, transcript_hasher>(
@@ -503,16 +503,16 @@ template<typename ppT, class transcript_hasher> void test_plonk_prover_rounds()
             witness,
             srs,
             hasher);
-    // clear hash buffer
+    // Clear hash buffer.
     hasher.buffer_clear();
-    // add outputs from Round 1 to the hash buffer
+    // Add outputs from Round 1 to the hash buffer.
     hasher.add_element(round_one_out.W_polys_blinded_at_secret_g1[a]);
     hasher.add_element(round_one_out.W_polys_blinded_at_secret_g1[b]);
     hasher.add_element(round_one_out.W_polys_blinded_at_secret_g1[c]);
     hasher.add_element(libff::Fr<ppT>::one());
-    // add outputs from Round 2 to the hash buffer
+    // Add outputs from Round 2 to the hash buffer.
     hasher.add_element(round_two_out.z_poly_at_secret_g1);
-    // add outputs from Round 3 to the hash buffer
+    // Add outputs from Round 3 to the hash buffer.
     hasher.add_element(round_three_out.t_poly_at_secret_g1[lo]);
     hasher.add_element(round_three_out.t_poly_at_secret_g1[mid]);
     hasher.add_element(round_three_out.t_poly_at_secret_g1[hi]);
@@ -525,20 +525,20 @@ template<typename ppT, class transcript_hasher> void test_plonk_prover_rounds()
     round_four_out_t<ppT> round_four_out =
         plonk_prover<ppT, transcript_hasher>::round_four(
             zeta, round_one_out, round_three_out, srs, hasher);
-    // clear hash buffer
+    // Clear hash buffer.
     hasher.buffer_clear();
-    // add outputs from Round 1 to the hash buffer
+    // Add outputs from Round 1 to the hash buffer.
     hasher.add_element(round_one_out.W_polys_blinded_at_secret_g1[a]);
     hasher.add_element(round_one_out.W_polys_blinded_at_secret_g1[b]);
     hasher.add_element(round_one_out.W_polys_blinded_at_secret_g1[c]);
     hasher.add_element(libff::Fr<ppT>::one());
-    // add outputs from Round 2 to the hash buffer
+    // Add outputs from Round 2 to the hash buffer.
     hasher.add_element(round_two_out.z_poly_at_secret_g1);
-    // add outputs from Round 3 to the hash buffer
+    // Add outputs from Round 3 to the hash buffer.
     hasher.add_element(round_three_out.t_poly_at_secret_g1[lo]);
     hasher.add_element(round_three_out.t_poly_at_secret_g1[mid]);
     hasher.add_element(round_three_out.t_poly_at_secret_g1[hi]);
-    // add outputs from Round 4 to the hash buffer
+    // Add outputs from Round 4 to the hash buffer.
     hasher.add_element(round_four_out.a_zeta);
     hasher.add_element(round_four_out.b_zeta);
     hasher.add_element(round_four_out.c_zeta);
@@ -570,7 +570,7 @@ template<typename ppT> void test_plonk_srs()
 
     ppT::init_public_params();
 
-    // load test vector values from example circuit
+    // Load test vector values from example circuit.
     plonk_example example;
     // random hidden element secret (toxic waste)
     Field secret = example.secret;
@@ -581,8 +581,8 @@ template<typename ppT> void test_plonk_srs()
         libfqfft::get_evaluation_domain<Field>(example.num_gates);
 
     // --- USRS ---
-    // compute SRS = powers of secret times G1: 1*G1, secret^1*G1,
-    // secret^2*G1, ... and secret times G2: 1*G2, secret^1*G2
+    // Compute SRS = powers of secret times G1: 1*G1, secret^1*G1,
+    // secret^2*G1, ... and secret times G2: 1*G2, secret^1*G2.
     usrs<ppT> usrs = plonk_usrs_derive_from_secret<ppT>(secret, max_degree);
     // --- SRS ---
     srs<ppT> srs = plonk_srs_derive_from_usrs<ppT>(
@@ -590,7 +590,7 @@ template<typename ppT> void test_plonk_srs()
         example.gates_matrix,
         example.wire_permutation,
         example.PI_wire_indices);
-    // compare SRS against reference test values
+    // Compare SRS against reference test values.
     printf("[%s:%d] secret ", __FILE__, __LINE__);
     secret.print();
     for (int i = 0; i < (int)srs.num_gates + 3; ++i) {
@@ -615,9 +615,9 @@ template<typename ppT, class transcript_hasher> void test_plonk_prover()
     using Field = libff::Fr<ppT>;
 
     ppT::init_public_params();
-    // load test vector values from example circuit
+    // Load test vector values from example circuit.
     plonk_example example;
-    // random hidden element secret (toxic waste)
+    // Random hidden element secret (toxic waste).
     Field secret = example.secret;
     // example witness
     std::vector<Field> witness = example.witness;
@@ -630,7 +630,7 @@ template<typename ppT, class transcript_hasher> void test_plonk_prover()
     std::shared_ptr<libfqfft::evaluation_domain<Field>> domain =
         libfqfft::get_evaluation_domain<Field>(example.num_gates);
 
-    // prepare srs
+    // Perepare srs.
     usrs<ppT> usrs = plonk_usrs_derive_from_secret<ppT>(secret, max_degree);
     srs<ppT> srs = plonk_srs_derive_from_usrs<ppT>(
         usrs,
@@ -638,15 +638,15 @@ template<typename ppT, class transcript_hasher> void test_plonk_prover()
         example.wire_permutation,
         example.PI_wire_indices);
 
-    // initialize hasher
+    // Initialize hasher.
     transcript_hasher hasher;
 
-    // initialize prover
+    // Initialize prover.
     plonk_prover<ppT, transcript_hasher> prover;
-    // compute proof
+    // Compute proof.
     plonk_proof<ppT> proof =
         prover.compute_proof(srs, witness, blind_scalars, hasher);
-    // compare proof against test vector values (debug)
+    // Compare proof against test vector values (debug).
     ASSERT_EQ(proof.a_zeta, example.a_zeta);
     ASSERT_EQ(proof.b_zeta, example.b_zeta);
     ASSERT_EQ(proof.c_zeta, example.c_zeta);
@@ -698,7 +698,7 @@ template<typename ppT, class transcript_hasher>
 void test_plonk_verifier_preprocessed_input(
     const plonk_example &example, const srs<ppT> &srs)
 {
-    // compute verifier preprocessed input
+    // Compute verifier preprocessed input.
     const verifier_preprocessed_input_t<ppT> preprocessed_input =
         plonk_verifier<ppT, transcript_hasher>::preprocessed_input(srs);
 
@@ -902,22 +902,22 @@ template<typename ppT, class transcript_hasher> void test_plonk_verifier_steps()
     using Field = libff::Fr<ppT>;
 
     ppT::init_public_params();
-    // load test vector values from example circuit
+    // Load test vector values from example circuit.
     plonk_example example;
-    // random hidden element secret (toxic waste)
+    // Random hidden element secret (toxic waste).
     Field secret = example.secret;
-    // example witness
+    // Example witness
     std::vector<Field> witness = example.witness;
-    // hard-coded values for the "random" blinding constants from
+    // Hard-coded values for the "random" blinding constants from.
     // example circuit
     std::vector<libff::Fr<ppT>> blind_scalars = example.prover_blind_scalars;
-    // maximum degree of the encoded monomials in the usrs
+    // Maximum degree of the encoded monomials in the usrs.
     size_t max_degree = PLONK_MAX_DEGREE;
 
     std::shared_ptr<libfqfft::evaluation_domain<Field>> domain =
         libfqfft::get_evaluation_domain<Field>(example.num_gates);
 
-    // prepare srs
+    // Prepare srs.
     usrs<ppT> usrs = plonk_usrs_derive_from_secret<ppT>(secret, max_degree);
     srs<ppT> srs = plonk_srs_derive_from_usrs<ppT>(
         usrs,
@@ -925,31 +925,31 @@ template<typename ppT, class transcript_hasher> void test_plonk_verifier_steps()
         example.wire_permutation,
         example.PI_wire_indices);
 
-    // initialize hasher
+    // Initialize hasher.
     transcript_hasher hasher;
 
-    // initialize prover
+    // Initialize prover.
     plonk_prover<ppT, transcript_hasher> prover;
-    // compute proof
+    // Compute proof.
     plonk_proof<ppT> proof =
         prover.compute_proof(srs, witness, blind_scalars, hasher);
 
-    // clear the hasher buffer in order to re-use the same
-    // transcript_hasher object for the verifier
+    // Clear the hasher buffer in order to re-use the same
+    // transcript_hasher object for the verifier.
     hasher.buffer_clear();
 
-    // Unit test verifier preprocessed input
+    // Unit test verifier preprocessed input.
     test_plonk_verifier_preprocessed_input<ppT, transcript_hasher>(
         example, srs);
 
-    // prepare the list of PI values for the example circuit
+    // Prepare the list of PI values for the example circuit.
     std::vector<Field> PI_value_list;
     for (size_t i = 0; i < example.PI_wire_indices.size(); i++) {
         Field PI_value = example.witness[example.PI_wire_indices[i]];
         PI_value_list.push_back(PI_value);
     }
 
-    // compute step 4
+    // Compute step 4
     const step_four_out_t<ppT> step_four_out =
         plonk_verifier<ppT, transcript_hasher>::step_four(proof, hasher);
 
@@ -1026,22 +1026,22 @@ template<typename ppT, class transcript_hasher> void test_plonk_verifier()
     using Field = libff::Fr<ppT>;
 
     ppT::init_public_params();
-    // load test vector values from example circuit
+    // Load test vector values from example circuit.
     plonk_example example;
-    // random hidden element secret (toxic waste)
+    // Random hidden element secret (toxic waste).
     Field secret = example.secret;
-    // example witness
+    // Example witness.
     std::vector<Field> witness = example.witness;
-    // hard-coded values for the "random" blinding constants from
-    // example circuit
+    // Hard-coded values for the "random" blinding constants from
+    // example circuit.
     std::vector<libff::Fr<ppT>> blind_scalars = example.prover_blind_scalars;
-    // maximum degree of the encoded monomials in the usrs
+    // Maximum degree of the encoded monomials in the usrs.
     size_t max_degree = PLONK_MAX_DEGREE;
 
     std::shared_ptr<libfqfft::evaluation_domain<Field>> domain =
         libfqfft::get_evaluation_domain<Field>(example.num_gates);
 
-    // prepare srs
+    // Prepare srs.
     usrs<ppT> usrs = plonk_usrs_derive_from_secret<ppT>(secret, max_degree);
     srs<ppT> srs = plonk_srs_derive_from_usrs<ppT>(
         usrs,
@@ -1049,37 +1049,37 @@ template<typename ppT, class transcript_hasher> void test_plonk_verifier()
         example.wire_permutation,
         example.PI_wire_indices);
 
-    // initialize hasher
+    // Initialize hasher.
     transcript_hasher hasher;
 
-    // initialize prover
+    // Initialize prover.
     plonk_prover<ppT, transcript_hasher> prover;
-    // compute proof
+    // Compute proof.
     plonk_proof<ppT> proof =
         prover.compute_proof(srs, witness, blind_scalars, hasher);
 
-    // clear the hasher buffer in order to re-use the same
-    // transcript_hasher object for the verifier
+    // Clear the hasher buffer in order to re-use the same
+    // transcript_hasher object for the verifier.
     hasher.buffer_clear();
 
-    // initialize verifier
+    // Initialize verifier.
     plonk_verifier<ppT, transcript_hasher> verifier;
-    // prepare the list of PI values for the example circuit
+    // Prepare the list of PI values for the example circuit.
     std::vector<Field> PI_value_list;
     for (size_t i = 0; i < example.PI_wire_indices.size(); i++) {
         Field PI_value = example.witness[example.PI_wire_indices[i]];
         PI_value_list.push_back(PI_value);
     }
-    // verify proof
+    // Verify proof.
     bool b_valid_proof =
         verifier.verify_proof(proof, srs, PI_value_list, hasher);
     ASSERT_TRUE(b_valid_proof);
 
-    // clear the hasher buffer in order to re-use the same
-    // transcript_hasher object
+    // Clear the hasher buffer in order to re-use the same
+    // transcript_hasher object.
     hasher.buffer_clear();
-    // assert that proof verification fails when the proof is
-    // manipulated
+    // Assert that proof verification fails when the proof is
+    // manipulated.
     test_verify_invalid_proof(proof, srs, PI_value_list, hasher);
 }
 
@@ -1088,7 +1088,7 @@ template<typename ppT, class transcript_hasher> void test_plonk_verifier()
 template<typename ppT> void test_plonk_gates_matrix_transpose()
 {
     using Field = libff::Fr<ppT>;
-    // load gates matrix from example circuit
+    // Load gates matrix from example circuit.
     plonk_example example;
     std::vector<std::vector<Field>> gates_matrix_transpose =
         plonk_gates_matrix_transpose(example.gates_matrix);
@@ -1103,37 +1103,37 @@ template<typename ppT> void test_plonk_constants_k1_k2()
     using Field = libff::Fr<ppT>;
 
     // Check that plonk_generate_constants_k1_k2 generates valid k1
-    // and k2
+    // and k2.
     Field k1, k2;
     plonk_generate_constants_k1_k2(k1, k2);
     ASSERT_TRUE(plonk_are_valid_constants_k1_k2(k1, k2));
 
-    // store the valid choices for k1,k2
+    // Store the valid choices for k1,k2.
     Field k1_valid = k1;
     Field k2_valid = k2;
-    // example value for the number of gates (must be power of 2)
+    // Example value for the number of gates (must be power of 2).
     size_t num_gates = 8;
-    // generate the n-th root of unity used as a generator of the
-    // multiplicative group H of size num_gates
+    // Generate the n-th root of unity used as a generator of the
+    // multiplicative group H of size num_gates.
     Field omega_base = libff::get_root_of_unity<Field>(num_gates);
 
     // Check that plonk_are_valid_constants_k1_k2 correctly detects
-    // invalid combinations of k1 and k2
+    // invalid combinations of k1 and k2.
     for (size_t i = 1; i <= num_gates; ++i) {
         size_t ipower = i;
-        // set k2 to an element of k1H:  k2=k1*(omega^i)
+        // Set k2 to an element of k1H:  k2=k1*(omega^i).
         k1 = k1_valid;
         k2 = k1 * (omega_base ^ ipower);
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
-        // set k1 to an element of k2H: k1=k2*(omega^i)
+        // Set k1 to an element of k2H: k1=k2*(omega^i).
         k2 = k2_valid;
         k1 = k2 * (omega_base ^ ipower);
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
-        // set k1 to an element of H: k1=omega^i
+        // Set k1 to an element of H: k1=omega^i.
         k1 = (omega_base ^ ipower);
         k2 = k2_valid;
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
-        // set k2 to an element of H: k2=omega^i
+        // Set k2 to an element of H: k2=omega^i.
         k1 = k1_valid;
         k2 = (omega_base ^ ipower);
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
@@ -1171,19 +1171,19 @@ void test_plonk_constants_k1_k2_bls12_381()
     // invalid combinations of k1 and k2.
     for (size_t i = 1; i <= example.num_gates; ++i) {
         size_t ipower = i;
-        // set k2 to an element of k1H:  k2=k1*(omega^i)
+        // Set k2 to an element of k1H:  k2=k1*(omega^i).
         k1 = example.k1;
         k2 = k1 * (example.omega_base ^ ipower);
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
-        // set k1 to an element of k2H: k1=k2*(omega^i)
+        // Set k1 to an element of k2H: k1=k2*(omega^i).
         k2 = example.k2;
         k1 = k2 * (example.omega_base ^ ipower);
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
-        // set k1 to an element of H: k1=omega^i
+        // Set k1 to an element of H: k1=omega^i.
         k1 = (example.omega_base ^ ipower);
         k2 = example.k2;
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
-        // set k2 to an element of H: k2=omega^i
+        // Set k2 to an element of H: k2=omega^i.
         k1 = example.k1;
         k2 = (example.omega_base ^ ipower);
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));

--- a/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
+++ b/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
@@ -1091,38 +1091,30 @@ template<typename ppT> void test_plonk_constants_k1_k2()
 {
     using Field = libff::Fr<ppT>;
     Field k1, k2;
-    // n = 2^s
-    //    const size_t n = std::pow(2, Field::s);
-    bool b_valid = false;
     // load k1,k2 from example circuit
     plonk_example example;
     k1 = example.k1;
     k2 = example.k2;
-    b_valid = plonk_are_valid_constants_k1_k2(k1, k2);
-    ASSERT_TRUE(b_valid);
+    ASSERT_TRUE(plonk_are_valid_constants_k1_k2(k1, k2));
     // check invalid k1,k2
     for (size_t i = 1; i <= example.num_gates; ++i) {
         size_t ipower = i;
         // invalid k2=k1*(omega^i)
         k1 = example.k1;
         k2 = k1 * (example.omega_base ^ ipower);
-        b_valid = plonk_are_valid_constants_k1_k2(k1, k2);
-        ASSERT_FALSE(b_valid);
+        ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
         // invalid k1=k2*(omega^i)
         k2 = example.k2;
         k1 = k2 * (example.omega_base ^ ipower);
-        b_valid = plonk_are_valid_constants_k1_k2(k1, k2);
-        ASSERT_FALSE(b_valid);
+        ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
         // invalid k1=omega^i
         k1 = (example.omega_base ^ ipower);
         k2 = example.k2;
-        b_valid = plonk_are_valid_constants_k1_k2(k1, k2);
-        ASSERT_FALSE(b_valid);
+        ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
         // invalid k2=omega^i
         k1 = example.k1;
         k2 = (example.omega_base ^ ipower);
-        b_valid = plonk_are_valid_constants_k1_k2(k1, k2);
-        ASSERT_FALSE(b_valid);
+        ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
     }
     // generate new k1,k2 and assert they are valid for a random
     // number of tests
@@ -1131,9 +1123,8 @@ template<typename ppT> void test_plonk_constants_k1_k2()
         k1 = 0;
         k2 = 0;
         plonk_generate_constants_k1_k2(k1, k2);
-        b_valid = plonk_are_valid_constants_k1_k2(k1, k2);
         // printf("k1 "); k1.print(); printf("k2 "); k2.print();
-        ASSERT_TRUE(b_valid);
+        ASSERT_TRUE(plonk_are_valid_constants_k1_k2(k1, k2));
     }
 }
 

--- a/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
+++ b/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
@@ -1162,14 +1162,14 @@ template<typename ppT> void test_plonk_constants_k1_k2_bls12_381()
     Field k1, k2;
 
     // Check that the example k1 and k2 are valid (according to
-    // plonk_are_valid_constants_k1_k2)"
+    // plonk_are_valid_constants_k1_k2.
     plonk_example example;
     k1 = example.k1;
     k2 = example.k2;
     ASSERT_TRUE(plonk_are_valid_constants_k1_k2(k1, k2));
 
     // Check that plonk_are_valid_constants_k1_k2 correctly detects
-    // invalid combinations of k1 and k2
+    // invalid combinations of k1 and k2.
     for (size_t i = 1; i <= example.num_gates; ++i) {
         size_t ipower = i;
         // set k2 to an element of k1H:  k2=k1*(omega^i)

--- a/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
+++ b/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
@@ -1103,7 +1103,18 @@ template<typename ppT> void test_plonk_constants_k1_k2()
     using Field = libff::Fr<ppT>;
     Field k1, k2;
     plonk_generate_constants_k1_k2(k1, k2);
-    // printf("k1 "); k1.print(); printf("k2 "); k2.print();
+    ASSERT_TRUE(plonk_are_valid_constants_k1_k2(k1, k2));
+}
+
+// generic test for all curves for an alternative method to generate
+// constants k1,k2 using randomization
+template<typename ppT> void test_plonk_random_constants_k1_k2()
+{
+    ppT::init_public_params();
+
+    using Field = libff::Fr<ppT>;
+    Field k1, k2;
+    plonk_generate_random_constants_k1_k2(k1, k2);
     ASSERT_TRUE(plonk_are_valid_constants_k1_k2(k1, k2));
 }
 
@@ -1150,48 +1161,55 @@ template<typename ppT> void test_plonk_constants_k1_k2_bls12_381()
     k1 = 0;
     k2 = 0;
     plonk_generate_constants_k1_k2(k1, k2);
-    // printf("k1 "); k1.print(); printf("k2 "); k2.print();
     ASSERT_TRUE(plonk_are_valid_constants_k1_k2(k1, k2));
 }
 
 TEST(TestPlonkConstantsK1K2, Edwards)
 {
     test_plonk_constants_k1_k2<libff::edwards_pp>();
+    test_plonk_random_constants_k1_k2<libff::edwards_pp>();
 }
 
 TEST(TestPlonkConstantsK1K2, Mnt4)
 {
     test_plonk_constants_k1_k2<libff::mnt4_pp>();
+    test_plonk_random_constants_k1_k2<libff::mnt4_pp>();
 }
 
 TEST(TestPlonkConstantsK1K2, Mnt6)
 {
     test_plonk_constants_k1_k2<libff::mnt6_pp>();
+    test_plonk_random_constants_k1_k2<libff::mnt6_pp>();
 }
 
 TEST(TestPlonkConstantsK1K2, BW6_761)
 {
     test_plonk_constants_k1_k2<libff::bw6_761_pp>();
+    test_plonk_random_constants_k1_k2<libff::bw6_761_pp>();
 }
 
 TEST(TestPlonkConstantsK1K2, BN128)
 {
     test_plonk_constants_k1_k2<libff::bn128_pp>();
+    test_plonk_random_constants_k1_k2<libff::bn128_pp>();
 }
 
 TEST(TestPlonkConstantsK1K2, ALT_BN128)
 {
     test_plonk_constants_k1_k2<libff::alt_bn128_pp>();
+    test_plonk_random_constants_k1_k2<libff::alt_bn128_pp>();
 }
 
 TEST(TestPlonkConstantsK1K2, BLS12_377)
 {
     test_plonk_constants_k1_k2<libff::bls12_377_pp>();
+    test_plonk_random_constants_k1_k2<libff::bls12_377_pp>();
 }
 
 TEST(TestPlonkConstantsK1K2, BLS12_381)
 {
     test_plonk_constants_k1_k2<libff::bls12_381_pp>();
+    test_plonk_random_constants_k1_k2<libff::bls12_381_pp>();
     test_plonk_constants_k1_k2_bls12_381<libff::bls12_381_pp>();
 }
 

--- a/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
+++ b/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
@@ -1096,22 +1096,23 @@ template<typename ppT> void test_plonk_constants_k1_k2()
     k1 = example.k1;
     k2 = example.k2;
     ASSERT_TRUE(plonk_are_valid_constants_k1_k2(k1, k2));
-    // check invalid k1,k2
+    // check invalid values for k1,k2 by setting one of them to be
+    // equal to an element of H, k1H or k2H
     for (size_t i = 1; i <= example.num_gates; ++i) {
         size_t ipower = i;
-        // invalid k2=k1*(omega^i)
+        // set k2 to an element of k1H:  k2=k1*(omega^i)
         k1 = example.k1;
         k2 = k1 * (example.omega_base ^ ipower);
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
-        // invalid k1=k2*(omega^i)
+        // set k1 to an element of k2H: k1=k2*(omega^i)
         k2 = example.k2;
         k1 = k2 * (example.omega_base ^ ipower);
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
-        // invalid k1=omega^i
+        // set k1 to an element of H: k1=omega^i
         k1 = (example.omega_base ^ ipower);
         k2 = example.k2;
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));
-        // invalid k2=omega^i
+        // set k2 to an element of H: k2=omega^i
         k1 = example.k1;
         k2 = (example.omega_base ^ ipower);
         ASSERT_FALSE(plonk_are_valid_constants_k1_k2(k1, k2));

--- a/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
+++ b/libsnark/zk_proof_systems/plonk/tests/test_plonk.cpp
@@ -1154,10 +1154,9 @@ template<typename ppT> void test_plonk_random_constants_k1_k2()
 
 // test specific to BLS12-381 (uses class example specific to
 // BLS12-381)
-template<typename ppT> void test_plonk_constants_k1_k2_bls12_381()
+void test_plonk_constants_k1_k2_bls12_381()
 {
-    ppT::init_public_params();
-
+    using ppT = libff::bls12_381_pp;
     using Field = libff::Fr<ppT>;
     Field k1, k2;
 
@@ -1237,7 +1236,7 @@ TEST(TestPlonkConstantsK1K2, BLS12_381)
 {
     test_plonk_constants_k1_k2<libff::bls12_381_pp>();
     test_plonk_random_constants_k1_k2<libff::bls12_381_pp>();
-    test_plonk_constants_k1_k2_bls12_381<libff::bls12_381_pp>();
+    test_plonk_constants_k1_k2_bls12_381();
 }
 
 TEST(TestPlonk, BLS12_381)

--- a/libsnark/zk_proof_systems/plonk/utils.hpp
+++ b/libsnark/zk_proof_systems/plonk/utils.hpp
@@ -199,7 +199,7 @@ std::vector<std::vector<FieldT>> plonk_gates_matrix_transpose(
 /// deterministically compute values for the constants k1,k2 \in Fr
 /// (section 8.1 [GWC19]) as k1=g^{2s}, k2=nqr, where s is the largest
 /// power of 2 such that 2^s < p and 2^{s+1} > p, p is the prime
-/// modulus of Fr and nqr is a quadratic nonresidue in Fr^*. both s
+/// modulus of Fr and nqr is a quadratic nonresidue in Fr^*. Both s
 /// and nqr are members of the class Fp_model defined in
 /// libff/libff/algebra/fields/fp.hpp .
 template<typename FieldT>
@@ -216,33 +216,14 @@ template<typename FieldT>
 void plonk_generate_random_constants_k1_k2(
     FieldT &k1_result, FieldT &k2_result);
 
-/// check that the constants k1,k2 \in Fr (section 8.1 [GWC19]) are
-/// valid. this is the case if the sets H, k1H, k2H are
-/// non-overlapping, where H = {w, w^1, w^2, ..., 2^n} is a
+/// Check that the constants k1,k2 \in Fr (section 8.1 [GWC19]) are
+/// valid. This is the case if the sets H, k1H, k2H are
+/// non-overlapping, where H = {w, w^1, w^2, ..., w^n} is a
 /// multiplicative subgroup of Fr of order n with generator w (denoted
 /// as \omega in [GWC19]). w is a primitive n-th root of unity in Fr
 /// and n is of the form 2^s where s is the largest power of 2 such
-/// that 2^s < p and 2^{s+1} > p, where p is the prime modulus of
-/// Fr. see also Section 8.1 in [GWC19]. note that p = 2^s * t + 1 so
-/// that p-1 = 2^s t is the order of the multiplicative group Fr^* of
-/// the scalar field Fr and s and t are members of the class Fp_model
-/// defined in libff/libff/algebra/fields/fp.hpp .
-///
-/// the function checks if the following three conditions are
-/// simultaneously satisfied:
-///
-/// 1) k1^n != 1 ensuring that k1 \notin H
-/// 2) k2^n != 1 ensuring that k2 \notin H
-/// 3) (k1 k2^-1)^n != 1 ensuring that k2H \notin k1H (and vice-versa)
-///
-/// to clarify 3), note that if (k1 k2^-1)^n == 1 then \exists i: 1 <=
-/// i <= n: k1 = k2 w^i and so k1 \in k2H. this is because k1 = k2 w^i
-/// is equivalent to k1 k2^-1 = w^i, equivalent to (k1 k2^-1)^n =
-/// (w^i)^n = 1. the latter follows from the fact that w^i is an n-th
-/// root of unity in Fr (for any i: 1<=i<=n).
-///
-/// conditions 1) and 2) are special cases of 3) for which resp. k1=1, k2=k1 and
-/// k1=1, k2=k2
+/// that 2^s | (r-1), where r is the prime modulus of Fr. See also
+/// Section 8.1 in [GWC19].
 template<typename FieldT>
 bool plonk_are_valid_constants_k1_k2(const FieldT &k1, const FieldT &k2);
 

--- a/libsnark/zk_proof_systems/plonk/utils.hpp
+++ b/libsnark/zk_proof_systems/plonk/utils.hpp
@@ -196,6 +196,47 @@ std::vector<std::vector<FieldT>> plonk_gates_matrix_transpose(
     const size_t &nrows,
     const size_t &ncols);
 
+/// generate constants k1,k2 \in Fr such that the sets H, k1H, k2H are
+/// non-overlapping, where H = {w, w^1, w^2, ..., 2^n} is a
+/// multiplicative subgroup of Fr of order n with generator w (denoted
+/// as \omega in [GWC19]). w is a primitive n-th root of unity in Fr
+/// and n is of the form 2^s where s is the largest power of 2 such
+/// that 2^s < p and 2^{s+1} > p, where p is the prime modulus of
+/// Fr. see also Section 8.1 in [GWC19]. note that p = 2^s * t + 1 so
+/// that p-1 = 2^s t is the order of the multiplicative group Fr^* of
+/// the scalar field Fr and s and t are members of the class Fp_model
+/// defined in libff/libff/algebra/fields/fp.hpp .
+///
+/// the algorithm generates random values for k1,k2 until the following
+/// three conditions are simultaneously satisfied:
+///
+/// 1) k1^n != 1 ensuring that k1 \notin H
+/// 2) k2^n != 1 ensuring that k2 \notin H
+/// 3) (k1 k2^-1)^n != 1 ensuring that k2H \notin k1H (and vice-versa)
+///
+/// to clarify 3), note that if (k1 k2^-1)^n == 1 then \exists i: 1 <=
+/// i <= n: k1 = k2 w^i and so k1 \in k2H. this is because k1 = k2 w^i
+/// is equivalent to k1 k2^-1 = w^i, equivalent to (k1 k2^-1)^n =
+/// (w^i)^n = 1. the latter follows from the fact that w^i is an n-th
+/// root of unity in Fr (for any i: 1<=i<=n).
+///
+/// conditions 1) and 2) are special cases of 3) for which resp. k1=1, k2=k1 and
+/// k1=1, k2=k2
+template<typename FieldT>
+void plonk_generate_constants_k1_k2(
+    const size_t &n, FieldT &k1_result, FieldT &k2_result);
+
+/// check that the constants k1,k2 satisfy the following conditions:
+///
+/// 1) k1 != 1 ensuring that k1 \notin H
+/// 2) k2 != 1 ensuring that k2 \notin H
+/// 3) (k1 k2^-1)^n != 1 ensuring that k2H \notin k1H (and vice-versa)
+///
+/// see Section 8.1 [GWC19] and plonk_generate_constants_k1_k2
+template<typename FieldT>
+bool plonk_are_valid_constants_k1_k2(
+    const size_t &n, const FieldT &k1, const FieldT &k2);
+
 } // namespace libsnark
 
 #include "libsnark/zk_proof_systems/plonk/utils.tcc"

--- a/libsnark/zk_proof_systems/plonk/utils.hpp
+++ b/libsnark/zk_proof_systems/plonk/utils.hpp
@@ -196,7 +196,28 @@ std::vector<std::vector<FieldT>> plonk_gates_matrix_transpose(
     const size_t &nrows,
     const size_t &ncols);
 
-/// generate constants k1,k2 \in Fr such that the sets H, k1H, k2H are
+/// deterministically compute values for the constants k1,k2 \in Fr
+/// (section 8.1 [GWC19]) as k1=g^{2s}, k2=nqr, where s is the largest
+/// power of 2 such that 2^s < p and 2^{s+1} > p, p is the prime
+/// modulus of Fr and nqr is a quadratic nonresidue in Fr^*. both s
+/// and nqr are members of the class Fp_model defined in
+/// libff/libff/algebra/fields/fp.hpp .
+template<typename FieldT>
+void plonk_generate_constants_k1_k2(FieldT &k1_result, FieldT &k2_result);
+
+/// generate values for the constants k1,k2 \in Fr (section 8.1
+/// [GWC19]) by trying random values until the following three
+/// conditions are simultaneously satisfied:
+///
+/// 1) k1^n != 1 ensuring that k1 \notin H
+/// 2) k2^n != 1 ensuring that k2 \notin H
+/// 3) (k1 k2^-1)^n != 1 ensuring that k2H \notin k1H (and vice-versa)
+template<typename FieldT>
+void plonk_generate_random_constants_k1_k2(
+    FieldT &k1_result, FieldT &k2_result);
+
+/// check that the constants k1,k2 \in Fr (section 8.1 [GWC19]) are
+/// valid. this is the case if the sets H, k1H, k2H are
 /// non-overlapping, where H = {w, w^1, w^2, ..., 2^n} is a
 /// multiplicative subgroup of Fr of order n with generator w (denoted
 /// as \omega in [GWC19]). w is a primitive n-th root of unity in Fr
@@ -207,8 +228,8 @@ std::vector<std::vector<FieldT>> plonk_gates_matrix_transpose(
 /// the scalar field Fr and s and t are members of the class Fp_model
 /// defined in libff/libff/algebra/fields/fp.hpp .
 ///
-/// the algorithm generates random values for k1,k2 until the following
-/// three conditions are simultaneously satisfied:
+/// the function checks if the following three conditions are
+/// simultaneously satisfied:
 ///
 /// 1) k1^n != 1 ensuring that k1 \notin H
 /// 2) k2^n != 1 ensuring that k2 \notin H
@@ -222,16 +243,6 @@ std::vector<std::vector<FieldT>> plonk_gates_matrix_transpose(
 ///
 /// conditions 1) and 2) are special cases of 3) for which resp. k1=1, k2=k1 and
 /// k1=1, k2=k2
-template<typename FieldT>
-void plonk_generate_constants_k1_k2(FieldT &k1_result, FieldT &k2_result);
-
-/// check that the constants k1,k2 satisfy the following conditions:
-///
-/// 1) k1^n != 1 ensuring that k1 \notin H
-/// 2) k2^n != 1 ensuring that k2 \notin H
-/// 3) (k1 k2^-1)^n != 1 ensuring that k2H \notin k1H (and vice-versa)
-///
-/// see Section 8.1 [GWC19] and plonk_generate_constants_k1_k2
 template<typename FieldT>
 bool plonk_are_valid_constants_k1_k2(const FieldT &k1, const FieldT &k2);
 

--- a/libsnark/zk_proof_systems/plonk/utils.hpp
+++ b/libsnark/zk_proof_systems/plonk/utils.hpp
@@ -223,19 +223,17 @@ std::vector<std::vector<FieldT>> plonk_gates_matrix_transpose(
 /// conditions 1) and 2) are special cases of 3) for which resp. k1=1, k2=k1 and
 /// k1=1, k2=k2
 template<typename FieldT>
-void plonk_generate_constants_k1_k2(
-    const size_t &n, FieldT &k1_result, FieldT &k2_result);
+void plonk_generate_constants_k1_k2(FieldT &k1_result, FieldT &k2_result);
 
 /// check that the constants k1,k2 satisfy the following conditions:
 ///
-/// 1) k1 != 1 ensuring that k1 \notin H
-/// 2) k2 != 1 ensuring that k2 \notin H
+/// 1) k1^n != 1 ensuring that k1 \notin H
+/// 2) k2^n != 1 ensuring that k2 \notin H
 /// 3) (k1 k2^-1)^n != 1 ensuring that k2H \notin k1H (and vice-versa)
 ///
 /// see Section 8.1 [GWC19] and plonk_generate_constants_k1_k2
 template<typename FieldT>
-bool plonk_are_valid_constants_k1_k2(
-    const size_t &n, const FieldT &k1, const FieldT &k2);
+bool plonk_are_valid_constants_k1_k2(const FieldT &k1, const FieldT &k2);
 
 } // namespace libsnark
 

--- a/libsnark/zk_proof_systems/plonk/utils.hpp
+++ b/libsnark/zk_proof_systems/plonk/utils.hpp
@@ -110,7 +110,7 @@ void plonk_compute_cosets_H_k1H_k2H(
     const FieldT k2,
     std::vector<FieldT> &H_prime);
 
-/// permute the multiplicative subgroup H according to the wire
+/// Permute the multiplicative subgroup H according to the wire
 /// permutation: (see [GWC19] Sect. 8), \see
 /// plonk_compute_roots_of_unity_omega, \see
 /// plonk_roots_of_unity_omega_to_subgroup_H
@@ -120,8 +120,8 @@ std::vector<FieldT> plonk_permute_subgroup_H(
     const std::vector<size_t> &wire_permutation,
     const size_t num_gates);
 
-/// compute the permutation polynomials S_sigma_1, S_sigma_2,
-/// S_sigma_2 (see [GWC19], Sect. 8.1)
+/// Compute the permutation polynomials S_sigma_1, S_sigma_2,
+/// S_sigma_2 (see [GWC19], Sect. 8.1).
 template<typename FieldT>
 std::vector<polynomial<FieldT>> plonk_compute_permutation_polynomials(
     const std::vector<FieldT> &H_prime_permute,
@@ -157,7 +157,7 @@ libff::G1<ppT> plonk_evaluate_poly_at_secret_G1(
     const polynomial<libff::Fr<ppT>> &f_poly);
 
 /// Evaluate a list of polynomials in the encrypted secret input: see
-/// plonk_evaluate_poly_at_secret_G1
+/// plonk_evaluate_poly_at_secret_G1.
 template<typename ppT>
 void plonk_evaluate_polys_at_secret_G1(
     const std::vector<libff::G1<ppT>> &secret_powers_g1,
@@ -165,8 +165,8 @@ void plonk_evaluate_polys_at_secret_G1(
     std::vector<libff::G1<ppT>> &Q_polys_at_secret_g1);
 
 /// Compute the factors in the product of the permutation polynomial
-/// z(X) in Prover Round 2. Note that accumulator A[0]=1 and A[i],
-/// i>0 is computed from values at i-1 for witness[i-1], H_prime[i-1],
+/// z(X) in Prover Round 2. Note that accumulator A[0]=1 and A[i], i>0
+/// is computed from values at i-1 for witness[i-1], H_prime[i-1],
 /// H_prime_permute[i-1]m etc.
 template<typename FieldT>
 FieldT plonk_compute_accumulator_factor(
@@ -196,7 +196,7 @@ std::vector<std::vector<FieldT>> plonk_gates_matrix_transpose(
     const size_t &nrows,
     const size_t &ncols);
 
-/// deterministically compute values for the constants k1,k2 \in Fr
+/// Deterministically compute values for the constants k1,k2 \in Fr
 /// (section 8.1 [GWC19]) as k1=g^{2s}, k2=nqr, where s is the largest
 /// power of 2 such that 2^s < p and 2^{s+1} > p, p is the prime
 /// modulus of Fr and nqr is a quadratic nonresidue in Fr^*. Both s
@@ -205,7 +205,7 @@ std::vector<std::vector<FieldT>> plonk_gates_matrix_transpose(
 template<typename FieldT>
 void plonk_generate_constants_k1_k2(FieldT &k1_result, FieldT &k2_result);
 
-/// generate values for the constants k1,k2 \in Fr (section 8.1
+/// Generate values for the constants k1,k2 \in Fr (section 8.1
 /// [GWC19]) by trying random values until the following three
 /// conditions are simultaneously satisfied:
 ///

--- a/libsnark/zk_proof_systems/plonk/utils.tcc
+++ b/libsnark/zk_proof_systems/plonk/utils.tcc
@@ -354,6 +354,21 @@ void plonk_generate_random_constants_k1_k2(FieldT &k1_result, FieldT &k2_result)
     assert(plonk_are_valid_constants_k1_k2(k1, k2));
 }
 
+// The function checks if the following three conditions are
+// simultaneously satisfied:
+//
+// 1) k1^n != 1 ensuring that k1 \notin H
+// 2) k2^n != 1 ensuring that k2 \notin H
+// 3) (k1 k2^-1)^n != 1 ensuring that k2H \notin k1H (and vice-versa)
+//
+// To clarify 3), note that if (k1 k2^-1)^n == 1 then \exists i: 1 <=
+// i <= n: k1 = k2 w^i and so k1 \in k2H. This is because k1 = k2 w^i
+// is equivalent to k1 k2^-1 = w^i, equivalent to (k1 k2^-1)^n =
+// (w^i)^n = 1. The latter follows from the fact that w^i is an n-th
+// root of unity in Fr (for any i: 1<=i<=n).
+//
+// conditions 1) and 2) are special cases of 3) for which resp. k1=1,
+// k2=k1 and k1=1, k2=k2
 template<typename FieldT>
 bool plonk_are_valid_constants_k1_k2(const FieldT &k1, const FieldT &k2)
 {

--- a/libsnark/zk_proof_systems/plonk/utils.tcc
+++ b/libsnark/zk_proof_systems/plonk/utils.tcc
@@ -342,10 +342,12 @@ bool plonk_are_valid_constants_k1_k2(const FieldT &k1, const FieldT &k2)
 {
     // n = 2^s: maximum order of the H subgroup that is power of 2
     const size_t n = std::pow(2, FieldT::s);
-    bool b_k1 = ((k1 ^ n) != FieldT::one());
-    bool b_k2 = ((k2 ^ n) != FieldT::one());
-    bool b_k1_k2 = (((k1 * k2.inverse()) ^ n) != FieldT::one());
-    return (b_k1 && b_k2 && b_k1_k2);
+    const bool k1_outside_H = ((k1 ^ n) != FieldT::one());
+    const bool k2_outside_H = ((k2 ^ n) != FieldT::one());
+    const bool k1_over_k2_outside_H =
+        (((k1 * k2.inverse()) ^ n) != FieldT::one());
+
+    return (k1_outside_H && k2_outside_H && k1_over_k2_outside_H);
 }
 
 } // namespace libsnark

--- a/libsnark/zk_proof_systems/plonk/utils.tcc
+++ b/libsnark/zk_proof_systems/plonk/utils.tcc
@@ -327,6 +327,8 @@ void plonk_generate_constants_k1_k2(FieldT &k1, FieldT &k2)
     k1 = g ^ n;
     // set k2 to a quadratic nonresidue of Fr^*
     k2 = FieldT::nqr;
+    // assert k1,k2 are valid
+    assert(plonk_are_valid_constants_k1_k2(k1, k2));
 }
 
 template<typename FieldT>
@@ -348,6 +350,8 @@ void plonk_generate_random_constants_k1_k2(FieldT &k1_result, FieldT &k2_result)
              (((k1_over_k2) ^ n) == FieldT::one()));
     k1_result = k1;
     k2_result = k2;
+    // assert k1,k2 are valid
+    assert(plonk_are_valid_constants_k1_k2(k1, k2));
 }
 
 template<typename FieldT>

--- a/libsnark/zk_proof_systems/plonk/utils.tcc
+++ b/libsnark/zk_proof_systems/plonk/utils.tcc
@@ -316,6 +316,36 @@ std::vector<std::vector<FieldT>> plonk_gates_matrix_transpose(
     return gates_matrix_transpose;
 }
 
+template<typename FieldT>
+void plonk_generate_constants_k1_k2(
+    const size_t &n, FieldT &k1_result, FieldT &k2_result)
+{
+    FieldT k1, k2;
+    // choose k1
+    do {
+        k1 = FieldT::random_element();
+    } while ((k1 ^ n) == FieldT::one());
+    // choose k2
+    FieldT k1_over_k2;
+    do {
+        k2 = FieldT::random_element();
+        k1_over_k2 = k1 * k2.inverse();
+    } while (((k2 ^ n) == FieldT::one()) ||
+             (((k1_over_k2) ^ n) == FieldT::one()));
+    k1_result = k1;
+    k2_result = k2;
+}
+
+template<typename FieldT>
+bool plonk_are_valid_constants_k1_k2(
+    const size_t &n, const FieldT &k1, const FieldT &k2)
+{
+    bool b_k1 = ((k1 ^ n) != FieldT::one());
+    bool b_k2 = ((k2 ^ n) != FieldT::one());
+    bool b_k1_k2 = (((k1 * k2.inverse()) ^ n) != FieldT::one());
+    return (b_k1 && b_k2 && b_k1_k2);
+}
+
 } // namespace libsnark
 
 #endif // LIBSNARK_ZK_PROOF_SYSTEMS_PLONK_UTILS_TCC_

--- a/libsnark/zk_proof_systems/plonk/utils.tcc
+++ b/libsnark/zk_proof_systems/plonk/utils.tcc
@@ -317,9 +317,10 @@ std::vector<std::vector<FieldT>> plonk_gates_matrix_transpose(
 }
 
 template<typename FieldT>
-void plonk_generate_constants_k1_k2(
-    const size_t &n, FieldT &k1_result, FieldT &k2_result)
+void plonk_generate_constants_k1_k2(FieldT &k1_result, FieldT &k2_result)
 {
+    // n = 2^s: maximum order of the H subgroup that is power of 2
+    const size_t n = std::pow(2, FieldT::s);
     FieldT k1, k2;
     // choose k1
     do {
@@ -337,9 +338,10 @@ void plonk_generate_constants_k1_k2(
 }
 
 template<typename FieldT>
-bool plonk_are_valid_constants_k1_k2(
-    const size_t &n, const FieldT &k1, const FieldT &k2)
+bool plonk_are_valid_constants_k1_k2(const FieldT &k1, const FieldT &k2)
 {
+    // n = 2^s: maximum order of the H subgroup that is power of 2
+    const size_t n = std::pow(2, FieldT::s);
     bool b_k1 = ((k1 ^ n) != FieldT::one());
     bool b_k2 = ((k2 ^ n) != FieldT::one());
     bool b_k1_k2 = (((k1 * k2.inverse()) ^ n) != FieldT::one());

--- a/libsnark/zk_proof_systems/plonk/utils.tcc
+++ b/libsnark/zk_proof_systems/plonk/utils.tcc
@@ -354,24 +354,25 @@ void plonk_generate_random_constants_k1_k2(FieldT &k1_result, FieldT &k2_result)
     assert(plonk_are_valid_constants_k1_k2(k1, k2));
 }
 
-// The function checks if the following three conditions are
-// simultaneously satisfied:
-//
-// 1) k1^n != 1 ensuring that k1 \notin H
-// 2) k2^n != 1 ensuring that k2 \notin H
-// 3) (k1 k2^-1)^n != 1 ensuring that k2H \notin k1H (and vice-versa)
-//
-// To clarify 3), note that if (k1 k2^-1)^n == 1 then \exists i: 1 <=
-// i <= n: k1 = k2 w^i and so k1 \in k2H. This is because k1 = k2 w^i
-// is equivalent to k1 k2^-1 = w^i, equivalent to (k1 k2^-1)^n =
-// (w^i)^n = 1. The latter follows from the fact that w^i is an n-th
-// root of unity in Fr (for any i: 1<=i<=n).
-//
-// conditions 1) and 2) are special cases of 3) for which resp. k1=1,
-// k2=k1 and k1=1, k2=k2
 template<typename FieldT>
 bool plonk_are_valid_constants_k1_k2(const FieldT &k1, const FieldT &k2)
 {
+    // The function checks if the following three conditions are
+    // simultaneously satisfied:
+    //
+    // 1) k1^n != 1 ensuring that k1 \notin H
+    // 2) k2^n != 1 ensuring that k2 \notin H
+    // 3) (k1 k2^-1)^n != 1 ensuring that k2H \notin k1H (and vice-versa)
+    //
+    // To clarify 3), note that if (k1 k2^-1)^n == 1 then \exists i: 1 <=
+    // i <= n: k1 = k2 w^i and so k1 \in k2H. This is because k1 = k2 w^i
+    // is equivalent to k1 k2^-1 = w^i, equivalent to (k1 k2^-1)^n =
+    // (w^i)^n = 1. The latter follows from the fact that w^i is an n-th
+    // root of unity in Fr (for any i: 1<=i<=n).
+    //
+    // conditions 1) and 2) are special cases of 3) for which resp. k1=1,
+    // k2=k1 and k1=1, k2=k2
+
     // n = 2^s: maximum order of the H subgroup that is power of 2
     const size_t n = std::pow(2, FieldT::s);
     const bool k1_outside_H = ((k1 ^ n) != FieldT::one());

--- a/libsnark/zk_proof_systems/plonk/utils.tcc
+++ b/libsnark/zk_proof_systems/plonk/utils.tcc
@@ -317,7 +317,20 @@ std::vector<std::vector<FieldT>> plonk_gates_matrix_transpose(
 }
 
 template<typename FieldT>
-void plonk_generate_constants_k1_k2(FieldT &k1_result, FieldT &k2_result)
+void plonk_generate_constants_k1_k2(FieldT &k1, FieldT &k2)
+{
+    // n = 2^s: maximum order of the H subgroup that is power of 2
+    const size_t n = std::pow(2, FieldT::s);
+    // generator of Fr^*
+    const FieldT g = FieldT::multiplicative_generator;
+    // set k1 = g^{2s} \notin H
+    k1 = g ^ n;
+    // set k2 to a quadratic nonresidue of Fr^*
+    k2 = FieldT::nqr;
+}
+
+template<typename FieldT>
+void plonk_generate_random_constants_k1_k2(FieldT &k1_result, FieldT &k2_result)
 {
     // n = 2^s: maximum order of the H subgroup that is power of 2
     const size_t n = std::pow(2, FieldT::s);

--- a/libsnark/zk_proof_systems/plonk/utils.tcc
+++ b/libsnark/zk_proof_systems/plonk/utils.tcc
@@ -89,7 +89,7 @@ void plonk_compute_roots_of_unity_omega(
     const FieldT k2,
     std::vector<std::vector<FieldT>> &omega)
 {
-    // ensure that num_gates is not 0 and is power of 2
+    // Ensure that num_gates is not 0 and is power of 2.
     // TODO: check also that it's less than 2^(ppT::s)
     bool b_nonzero = (num_gates > 0);
     bool b_is_power2 = ((num_gates & (num_gates - 1)) == 0);
@@ -125,7 +125,7 @@ void plonk_compute_cosets_H_k1H_k2H(
     const FieldT k2,
     std::vector<FieldT> &H_prime)
 {
-    // ensure that num_gates is not 0 and is power of 2
+    // Ensure that num_gates is not 0 and is power of 2.
     bool b_nonzero = (num_gates > 0);
     bool b_is_power2 = ((num_gates & (num_gates - 1)) == 0);
     if (!(b_nonzero && b_is_power2)) {
@@ -323,9 +323,9 @@ void plonk_generate_constants_k1_k2(FieldT &k1, FieldT &k2)
     const size_t n = std::pow(2, FieldT::s);
     // generator of Fr^*
     const FieldT g = FieldT::multiplicative_generator;
-    // set k1 = g^{2s} \notin H
+    // Set k1 = g^{2s} \notin H.
     k1 = g ^ n;
-    // set k2 to a quadratic nonresidue of Fr^*
+    // Set k2 to a quadratic nonresidue of Fr^* .
     k2 = FieldT::nqr;
     // assert k1,k2 are valid
     assert(plonk_are_valid_constants_k1_k2(k1, k2));

--- a/libsnark/zk_proof_systems/plonk/verifier.tcc
+++ b/libsnark/zk_proof_systems/plonk/verifier.tcc
@@ -59,7 +59,7 @@ template<typename ppT, class transcript_hasher>
 step_four_out_t<ppT> plonk_verifier<ppT, transcript_hasher>::step_four(
     const plonk_proof<ppT> &proof, transcript_hasher &hasher)
 {
-    // add outputs from Round 1 to the hash buffer
+    // Add outputs from Round 1 to the hash buffer.
     hasher.add_element(proof.W_polys_blinded_at_secret_g1[a]);
     hasher.add_element(proof.W_polys_blinded_at_secret_g1[b]);
     hasher.add_element(proof.W_polys_blinded_at_secret_g1[c]);
@@ -72,19 +72,20 @@ step_four_out_t<ppT> plonk_verifier<ppT, transcript_hasher>::step_four(
     hasher.add_element(libff::Fr<ppT>::one());
     libff::Fr<ppT> gamma = hasher.get_hash();
 
-    // add outputs from Round 2 to the hash buffer
+    // Add outputs from Round 2 to the hash buffer.
     hasher.add_element(proof.z_poly_at_secret_g1);
     // - alpha: quotient challenge - hash of transcript of rounds 1,2
     libff::Fr<ppT> alpha = hasher.get_hash();
 
-    // add outputs from Round 3 to the hash buffer
+    // Add outputs from Round 3 to the hash buffer.
     hasher.add_element(proof.t_poly_at_secret_g1[lo]);
     hasher.add_element(proof.t_poly_at_secret_g1[mid]);
     hasher.add_element(proof.t_poly_at_secret_g1[hi]);
-    // - zeta: evaluation challenge - hash of transcriptof rounds 1,2,3
+    // - zeta: evaluation challenge - hash of transcriptof rounds
+    // - 1,2,3
     libff::Fr<ppT> zeta = hasher.get_hash();
 
-    // add outputs from Round 4 to the hash buffer
+    // Add outputs from Round 4 to the hash buffer.
     hasher.add_element(proof.a_zeta);
     hasher.add_element(proof.b_zeta);
     hasher.add_element(proof.c_zeta);
@@ -95,7 +96,7 @@ step_four_out_t<ppT> plonk_verifier<ppT, transcript_hasher>::step_four(
     //   [GWC19])
     libff::Fr<ppT> nu = hasher.get_hash();
 
-    // add outputs from Round 5 to the hash buffer
+    // Add outputs from Round 5 to the hash buffer.
     hasher.add_element(proof.r_zeta);
     hasher.add_element(proof.W_zeta_at_secret);
     hasher.add_element(proof.W_zeta_omega_at_secret);
@@ -157,15 +158,16 @@ step_seven_out_t<ppT> plonk_verifier<ppT, transcript_hasher>::step_seven(
 {
     std::shared_ptr<libfqfft::evaluation_domain<Field>> domain =
         libfqfft::get_evaluation_domain<Field>(srs.num_gates);
-    // construct the PI polynomial from the vector of PI values (received as
-    // input to the verifier) and the PI wire indices (stored in the srs)
+    // Construct the PI polynomial from the vector of PI values
+    // (received as input to the verifier) and the PI wire indices
+    // (stored in the srs).
     std::vector<Field> PI_points(srs.num_gates, Field(0));
     for (size_t i = 0; i < PI_value_list.size(); i++) {
         size_t PI_coordinate_x = srs.PI_wire_indices[i] % srs.num_gates;
         PI_points[PI_coordinate_x] = Field(-PI_value_list[i]);
     }
 
-    // compute PI polynomial
+    // Compute PI polynomial.
     polynomial<Field> PI_poly;
     plonk_compute_public_input_polynomial(PI_points, PI_poly, domain);
 
@@ -193,7 +195,7 @@ step_eight_out_t<ppT> plonk_verifier<ppT, transcript_hasher>::step_eight(
     libff::Fr<ppT> r_prime_zeta;
     Field alpha_power2 = libff::power(step_four_out.alpha, libff::bigint<1>(2));
 
-    // compute polynomial r'(zeta) = r(zeta) - r_0
+    // Compute polynomial r'(zeta) = r(zeta) - r_0 .
     std::vector<Field> r_prime_parts(5);
     r_prime_parts[0] = proof.r_zeta + step_seven_out.PI_zeta;
     r_prime_parts[1] =
@@ -234,7 +236,7 @@ step_nine_out_t<ppT> plonk_verifier<ppT, transcript_hasher>::step_nine(
 
     Field alpha_power2 = libff::power(step_four_out.alpha, libff::bigint<1>(2));
 
-    // compute D1_part[0]:
+    // Compute D1_part[0]:
     // (a_bar b_bar [q_M]_1 + a_bar [q_L]_1 + b_bar [q_R]_1 + c_bar [q_O]_1 +
     // [q_C]_1) nu Note: the paper omits the final multiplication by nu
     std::vector<libff::G1<ppT>> curve_points{
@@ -251,7 +253,7 @@ step_nine_out_t<ppT> plonk_verifier<ppT, transcript_hasher>::step_nine(
         step_four_out.nu};
     D1_part[0] = plonk_multi_exp_G1<ppT>(curve_points, scalar_elements);
 
-    // compute D1_part[1]:
+    // Compute D1_part[1]:
     // ((a_bar + beta zeta + gamma)(b_bar + beta k1 zeta + gamma)(c_bar + beta
     // k2 zeta + gamma) alpha + L1(zeta) alpha^2 + u) [z]_1
     Field D1_part1_scalar =
@@ -266,7 +268,7 @@ step_nine_out_t<ppT> plonk_verifier<ppT, transcript_hasher>::step_nine(
         step_four_out.u;
     D1_part[1] = D1_part1_scalar * proof.z_poly_at_secret_g1;
 
-    // compute D1_part[2]:
+    // Compute D1_part[2]:
     // (a_bar + beta s_sigma1_bar + gamma)(b_bar + beta s_sigma2_bar +
     // gamma)alpha beta z_preprocessed_input.omega_roots_bar [s_sigma3]_1
     Field D1_part2_scalar =
@@ -279,7 +281,7 @@ step_nine_out_t<ppT> plonk_verifier<ppT, transcript_hasher>::step_nine(
         Field(-1);
     D1_part[2] = D1_part2_scalar * preprocessed_input.S_polys_at_secret_g1[2];
 
-    // Compute D1 = D1_part[0] + D1_part[1] + D1_part[2]
+    // Compute D1 = D1_part[0] + D1_part[1] + D1_part[2] .
     D1 = D1_part[0] + D1_part[1] + D1_part[2];
 
     step_nine_out_t<ppT> step_nine_out(std::move(D1));
@@ -420,7 +422,7 @@ bool plonk_verifier<ppT, transcript_hasher>::verify_proof(
     std::shared_ptr<libfqfft::evaluation_domain<libff::Fr<ppT>>> domain =
         libfqfft::get_evaluation_domain<libff::Fr<ppT>>(srs.num_gates);
 
-    // compute verifier preprocessed input
+    // Compute verifier preprocessed input.
     const verifier_preprocessed_input_t<ppT> preprocessed_input =
         plonk_verifier::preprocessed_input(srs);
 


### PR DESCRIPTION
Functions to generate constants $k_1$ and $k_2$ (section 8.1 [GWC19]) and check their validity. This PR addresses Issue #90. Note that the issue number in the name of the branch is mistakenly set to 70 instead of 90 i.e., the branch should be called `90-plonk-setting-k1-k2` instead of `70-plonk-setting-k1-k2` .