### PR TITLE
Anemoi hash r1cs numstatecolumns

### DIFF
--- a/libsnark/gadgetlib1/gadgets/hashes/anemoi/anemoi_components.hpp
+++ b/libsnark/gadgetlib1/gadgets/hashes/anemoi/anemoi_components.hpp
@@ -241,23 +241,26 @@ template<typename ppT, size_t NumStateColumns_L> class anemoi_permutation_mds;
 
 template<typename ppT> class anemoi_permutation_mds<ppT, 2>
 {
+    using anemoi_mds_matrix_t = std::array<std::array<libff::Fr<ppT>, 2>, 2>;
+
 public:
-    static std::array<std::array<libff::Fr<ppT>, 2>, 2> permutation_mds(
-        const libff::Fr<ppT> g);
+    static anemoi_mds_matrix_t permutation_mds(const libff::Fr<ppT> g);
 };
 
 template<typename ppT> class anemoi_permutation_mds<ppT, 3>
 {
+    using anemoi_mds_matrix_t = std::array<std::array<libff::Fr<ppT>, 3>, 3>;
+
 public:
-    static std::array<std::array<libff::Fr<ppT>, 3>, 3> permutation_mds(
-        const libff::Fr<ppT> g);
+    static anemoi_mds_matrix_t permutation_mds(const libff::Fr<ppT> g);
 };
 
 template<typename ppT> class anemoi_permutation_mds<ppT, 4>
 {
+    using anemoi_mds_matrix_t = std::array<std::array<libff::Fr<ppT>, 4>, 4>;
+
 public:
-    static std::array<std::array<libff::Fr<ppT>, 4>, 4> permutation_mds(
-        const libff::Fr<ppT> g);
+    static anemoi_mds_matrix_t permutation_mds(const libff::Fr<ppT> g);
 };
 
 } // namespace libsnark

--- a/libsnark/gadgetlib1/gadgets/hashes/anemoi/anemoi_components.hpp
+++ b/libsnark/gadgetlib1/gadgets/hashes/anemoi/anemoi_components.hpp
@@ -183,11 +183,6 @@ public:
     void generate_r1cs_witness();
 };
 
-// get the MDS matrix from the number of columns 2,3 or 4
-template<typename FieldT, size_t NumStateColumns_L>
-std::array<std::array<FieldT, NumStateColumns_L>, NumStateColumns_L>
-anemoi_permutation_mds(const FieldT g);
-
 /// One round of the Anemoi permutation mapping (Fr)^{2L} -> (Fr)^{2L}
 ///
 /// NumStateColumns_L : L parameter - number of columns in the
@@ -239,6 +234,30 @@ public:
 
     void generate_r1cs_constraints();
     void generate_r1cs_witness();
+};
+
+// MDS matrix for each allowed dimension: 2,3 or 4
+template<typename ppT, size_t NumStateColumns_L> class anemoi_permutation_mds;
+
+template<typename ppT> class anemoi_permutation_mds<ppT, 2>
+{
+public:
+    static std::array<std::array<libff::Fr<ppT>, 2>, 2> permutation_mds(
+        const libff::Fr<ppT> g);
+};
+
+template<typename ppT> class anemoi_permutation_mds<ppT, 3>
+{
+public:
+    static std::array<std::array<libff::Fr<ppT>, 3>, 3> permutation_mds(
+        const libff::Fr<ppT> g);
+};
+
+template<typename ppT> class anemoi_permutation_mds<ppT, 4>
+{
+public:
+    static std::array<std::array<libff::Fr<ppT>, 4>, 4> permutation_mds(
+        const libff::Fr<ppT> g);
 };
 
 } // namespace libsnark

--- a/libsnark/gadgetlib1/gadgets/hashes/anemoi/anemoi_components.tcc
+++ b/libsnark/gadgetlib1/gadgets/hashes/anemoi/anemoi_components.tcc
@@ -582,6 +582,20 @@ void anemoi_permutation_round_prime_field_gadget<
     }
 }
 
+// TODO: consdier applying the following changes to all
+// anemoi_permutation_mds::permutation_mds functions in order to
+// remove the input g parameter:
+//
+// - extract the ppT part from the anemoi_parameters class
+//
+// - use the ppT part from the anemoi_parameters class to implicitly
+//   get the value of g as
+//   anemoi_parameters<ppT>::multiplicative_generator_g;
+//
+// - remove the input parameter const libff::Fr<ppT> g from all
+//   permutation_mds functions and extract g as above
+//
+// see: https://github.com/clearmatics/libsnark/pull/102#discussion_r1071444422
 template<typename ppT>
 std::array<std::array<libff::Fr<ppT>, 2>, 2> anemoi_permutation_mds<ppT, 2>::
     permutation_mds(const libff::Fr<ppT> g)

--- a/libsnark/gadgetlib1/gadgets/hashes/anemoi/anemoi_components.tcc
+++ b/libsnark/gadgetlib1/gadgets/hashes/anemoi/anemoi_components.tcc
@@ -500,12 +500,57 @@ anemoi_permutation_round_prime_field_gadget<
         Z_right.push_back(X_right[i] + D[i]);
     }
 
-    if (ncols > 1) {
-        M_matrix = anemoi_permutation_mds<ppT, ncols>::permutation_mds(g);
-    } else { // ncols == 1
-        // the MDS matrix for a state with 1 column (L=1) is the same as
-        // for a state with 2 columns (L=2)
-        M_matrix = anemoi_permutation_mds<ppT, 2>::permutation_mds(g);
+    // Note 1: the sequence of if-s over ncols \in {1,2,3,4} that
+    // follows is due to the fact that the specialized class
+    // anemoi_permutation_mds<ppT, n> only accepts const size_t n =
+    // <value>, but it would not accept const size_t =
+    // NumStateColumns_L. TODO: fix using a more efficient approach.
+
+    // Note 2: the for-loop within each if(ncols == <value>), copies
+    // the 2d array returned by anemoi_permutation_mds<ppT,
+    // n>::permutation_mds(g) into a 2d vector which is the type of
+    // the class member M_matrix. TODO: fix this by either using a
+    // more efficient approach or changing the type of M_matrix to be
+    // of type 2d array.
+
+    // Note 3: for matrix-vector multiplication we currently provide
+    // fast routines for dimensions NumStateColumns_L \in {2,3,4} that
+    // only accept g and a vector as input (the
+    // anemoi_fast_multiply_mds_* functions). Therefore the class
+    // member M_matrix is not used at the moment. It is included for
+    // future use for 2 foreseeable scenarios: 1) an instance of
+    // Anemoi with NumStateColumns_L > 4 for which we do not have a
+    // fast multiplication routine and 2) keep the possibility to
+    // still use normal matrix-vector multiplication if one wants to
+
+    // the MDS matrix for a state with 1 column (L=1) is the same as
+    // for a state with 2 columns (L=2)
+    if ((ncols == 1) || (ncols == 2)) {
+        const size_t n = 2;
+        std::array<std::array<FieldT, n>, n> M =
+            anemoi_permutation_mds<ppT, n>::permutation_mds(g);
+        for (size_t i = 0; i < n; ++i) {
+            std::vector<FieldT> v(std::begin(M[i]), std::end(M[i]));
+            M_matrix.push_back(v);
+        }
+    }
+    if (ncols == 3) {
+        const size_t n = 3;
+        std::array<std::array<FieldT, n>, n> M =
+            anemoi_permutation_mds<ppT, n>::permutation_mds(g);
+        for (size_t i = 0; i < n; ++i) {
+            std::vector<FieldT> v(std::begin(M[i]), std::end(M[i]));
+            M_matrix.push_back(v);
+        }
+    }
+    if (ncols == 4) {
+        const size_t n = 4;
+        std::array<std::array<FieldT, n>, n> M =
+            anemoi_permutation_mds<ppT, n>::permutation_mds(g);
+        for (size_t i = 0; i < n; ++i) {
+            std::vector<FieldT> v(std::begin(M[i]), std::end(M[i]));
+            M_matrix.push_back(v);
+        }
     }
 
     // multiply by matrix M

--- a/libsnark/gadgetlib1/gadgets/hashes/anemoi/anemoi_components.tcc
+++ b/libsnark/gadgetlib1/gadgets/hashes/anemoi/anemoi_components.tcc
@@ -90,7 +90,6 @@ void flystel_Q_prime_field_gadget<ppT>::generate_r1cs_witness()
 //
 // where A0=(0, beta, 0, 0), B0=(0, 1, 0, 0), C0=(0, 0, 1, 0) and
 // A1=(0, 0, 1, 0), B1=(0, 1, 0, 0), C1=(-gamma, 0, 0, 1)
-
 template<typename ppT>
 flystel_Q_binary_field_gadget<ppT>::flystel_Q_binary_field_gadget(
     protoboard<libff::Fr<ppT>> &pb,

--- a/libsnark/gadgetlib1/gadgets/hashes/anemoi/tests/test_anemoi_gadget.cpp
+++ b/libsnark/gadgetlib1/gadgets/hashes/anemoi/tests/test_anemoi_gadget.cpp
@@ -301,6 +301,43 @@ void test_anemoi_permutation_round_prime_field_gadget()
         "anemoi_permutation_round_prime_field_gadget tests successful");
 }
 
+template<typename ppT, class parameters = anemoi_parameters<libff::Fr<ppT>>>
+void test_anemoi_permutation_mds()
+{
+    // anemoi_permutation_mds<ppT, NumStateColumnsL>::permutation_mds()
+    using FieldT = libff::Fr<ppT>;
+    const FieldT g = anemoi_parameters<ppT>::multiplicative_generator_g;
+    // NumStateColumnsL == 2
+    {
+        const size_t NumStateColumnsL = 2;
+        std::array<std::array<FieldT, NumStateColumnsL>, NumStateColumnsL>
+            M_expect = {{{1, 7}, {7, 50}}};
+        std::array<std::array<FieldT, NumStateColumnsL>, NumStateColumnsL> M =
+            anemoi_permutation_mds<ppT, NumStateColumnsL>::permutation_mds(g);
+        ASSERT_EQ(M, M_expect);
+    }
+    // NumStateColumnsL == 3
+    {
+        const size_t NumStateColumnsL = 3;
+        std::array<std::array<FieldT, NumStateColumnsL>, NumStateColumnsL>
+            M_expect = {{{8, 1, 8}, {1, 1, 7}, {7, 1, 1}}};
+        std::array<std::array<FieldT, NumStateColumnsL>, NumStateColumnsL> M =
+            anemoi_permutation_mds<ppT, NumStateColumnsL>::permutation_mds(g);
+        ASSERT_EQ(M, M_expect);
+    }
+    // NumStateColumnsL == 4
+    {
+        const size_t NumStateColumnsL = 4;
+        std::array<std::array<FieldT, NumStateColumnsL>, NumStateColumnsL>
+            M_expect = {
+                {{1, 8, 7, 7}, {49, 56, 8, 15}, {49, 49, 1, 8}, {8, 15, 7, 8}}};
+        std::array<std::array<FieldT, NumStateColumnsL>, NumStateColumnsL> M =
+            anemoi_permutation_mds<ppT, NumStateColumnsL>::permutation_mds(g);
+        ASSERT_EQ(M, M_expect);
+    }
+    libff::print_time("anemoi_permutation_mds tests successful");
+}
+
 template<typename ppT> void test_for_curve()
 {
     // Execute all tests for the given curve.
@@ -319,6 +356,7 @@ template<typename ppT> void test_for_curve()
     test_anemoi_permutation_round_prime_field_gadget<ppT, 2, parameters>();
     test_anemoi_permutation_round_prime_field_gadget<ppT, 3, parameters>();
     test_anemoi_permutation_round_prime_field_gadget<ppT, 4, parameters>();
+    test_anemoi_permutation_mds<ppT, parameters>();
 }
 
 TEST(TestAnemoiGadget, BLS12_381) { test_for_curve<libff::bls12_381_pp>(); }

--- a/libsnark/gadgetlib1/gadgets/hashes/anemoi/tests/test_anemoi_gadget.cpp
+++ b/libsnark/gadgetlib1/gadgets/hashes/anemoi/tests/test_anemoi_gadget.cpp
@@ -8,6 +8,7 @@
 
 #include "libsnark/gadgetlib1/gadgets/hashes/anemoi/tests/anemoi_outputs.hpp"
 
+#include <array>
 #include <gtest/gtest.h>
 #include <libff/algebra/curves/bls12_381/bls12_381_init.hpp>
 #include <libff/algebra/curves/bls12_381/bls12_381_pp.hpp>


### PR DESCRIPTION
Rebase [anemoi-hash-r1cs-numstatecolumns](https://github.com/clearmatics/libsnark/tree/anemoi-hash-r1cs-numstatecolumns) onto base branch [anemoi-hash-r1cs](https://github.com/clearmatics/libsnark/tree/anemoi-hash-r1cs). See PR #79 [FROZEN] which was automatically closed after deleting branch [anemoi-hash-r1cs-parametrization](https://github.com/clearmatics/libsnark/tree/anemoi-hash-r1cs-parametrization) . This branch implements specialised implementations of multiplication by the MDS matrix for valid values of `NumStateColumns_L`. In contrast, the method used in the base branch is a single function for all matrix sizes (1,2,3,4) with static assert check on the dimensions (https://github.com/clearmatics/libsnark/blob/anemoi-hash-r1cs/libsnark/gadgetlib1/gadgets/hashes/anemoi/anemoi_components.tcc#L326). See the last bullet in https://github.com/clearmatics/libsnark/issues/77 and https://github.com/clearmatics/libsnark/pull/65#discussion_r992467709 .